### PR TITLE
add plot configuration tab 

### DIFF
--- a/NetPyNETabs.js
+++ b/NetPyNETabs.js
@@ -9,6 +9,7 @@ import NetPyNESynapses from './components/definition/synapses/NetPyNESynapses';
 import NetPyNEConnectivityRules from './components/definition/connectivity/NetPyNEConnectivityRules';
 import NetPyNEStimulationSources from './components/definition/stimulation/NetPyNEStimulationSources';
 import NetPyNEStimulationTargets from './components/definition/stimulation/NetPyNEStimulationTargets';
+import NetPyNEPlots from './components/definition/plots/NetPyNEPlots';
 import NetPyNESimConfig from './components/definition/configuration/NetPyNESimConfig';
 import NetPyNEInstantiated from './components/instantiation/NetPyNEInstantiated';
 import Utils from './Utils';
@@ -17,7 +18,6 @@ import SettingsDialog from './components/settings/Settings';
 import TransitionDialog from './components/transition/Transition';
 import FontIcon from 'material-ui/FontIcon';
 
-
 var PythonControlledCapability = require('../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledNetPyNEPopulations = PythonControlledCapability.createPythonControlledComponent(NetPyNEPopulations);
 var PythonControlledNetPyNECellRules = PythonControlledCapability.createPythonControlledComponent(NetPyNECellRules);
@@ -25,6 +25,7 @@ var PythonControlledNetPyNESynapses = PythonControlledCapability.createPythonCon
 var PythonControlledNetPyNEConnectivity = PythonControlledCapability.createPythonControlledComponent(NetPyNEConnectivityRules);
 var PythonControlledNetPyNEStimulationSources = PythonControlledCapability.createPythonControlledComponent(NetPyNEStimulationSources);
 var PythonControlledNetPyNEStimulationTargets = PythonControlledCapability.createPythonControlledComponent(NetPyNEStimulationTargets);
+var PythonControlledNetPyNEPlots = PythonControlledCapability.createPythonControlledComponent(NetPyNEPlots);
 
 export default class NetPyNETabs extends React.Component {
 
@@ -132,6 +133,7 @@ export default class NetPyNETabs extends React.Component {
         <PythonControlledNetPyNEStimulationSources model={"netParams.stimSourceParams"} />
         <PythonControlledNetPyNEStimulationTargets model={"netParams.stimTargetParams"} />
         <NetPyNESimConfig model={this.state.model.simConfig} />
+        <PythonControlledNetPyNEPlots model={"simConfig.analysis"} />
       </div>
     ) : (<div></div>);
     var exploreContent = this.state.value == "explore" ? (<NetPyNEInstantiated ref={"explore"} model={this.state.model} page={"explore"} />) : (<div></div>);

--- a/components/definition/plots/NetPyNENewPlot.js
+++ b/components/definition/plots/NetPyNENewPlot.js
@@ -1,0 +1,79 @@
+import React, { Component } from 'react';
+import FloatingActionButton from 'material-ui/FloatingActionButton';
+import ContentAdd from 'material-ui/svg-icons/content/add';
+import Popover from 'material-ui/Popover';
+import Menu from 'material-ui/Menu';
+import MenuItem from 'material-ui/MenuItem';
+
+const styles = {
+  addButton: {
+    margin: 10,
+    float: 'left'
+  }
+};
+
+export default class NetPyNENewPlot extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+    };
+    this.handleClick = this.handleClick.bind(this);
+    this.handleButtonClick = this.handleButtonClick.bind(this);
+  };
+  
+  handleButtonClick = (event) => {
+    // This prevents ghost click.
+    event.preventDefault();
+    this.setState({
+      open: true,
+      anchorEl: event.currentTarget,
+    });
+  };
+
+  handleRequestClose = () => {
+    this.setState({
+      open: false,
+    });
+  };
+  
+  handleClick(event, value) {
+    this.handleRequestClose();
+    this.props.handleClick(value);
+  };
+  
+  MenuItems() {
+    var Plots  = ["plotRaster", "plotSpikeHist", "plotSpikeStats"]
+        Plots.push(... ["plotRatePSD", "plotTraces", "plotLFP", "plotShape"])
+        Plots.push(...["plot2Dnet", "plotConn", "granger"])
+    return Plots.map((name) => (
+      <MenuItem
+        key={name}
+        value={name}
+        primaryText={name}
+      />
+    ));
+  };
+  
+  render() {
+    return (
+      <div>
+        <FloatingActionButton mini={true} style={styles.addButton} onClick={this.handleButtonClick}>
+          <ContentAdd />
+        </FloatingActionButton>
+        <Popover
+          open={this.state.open}
+          anchorEl={this.state.anchorEl}
+          anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
+          targetOrigin={{horizontal: 'left', vertical: 'top'}}
+          onRequestClose={this.handleRequestClose}
+        >
+          <Menu onChange={this.handleClick}>
+            {this.MenuItems()}
+          </Menu>
+        </Popover>
+      </div>
+    );
+  }
+}

--- a/components/definition/plots/NetPyNEPlot.js
+++ b/components/definition/plots/NetPyNEPlot.js
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import PlotLFP from './plotTypes/PlotLFP';
+import PlotConn from './plotTypes/PlotConn';
+import PlotShape from './plotTypes/PlotShape';
+import Plot2Dnet from './plotTypes/Plot2Dnet';
+import PlotRaster from './plotTypes/PlotRaster';
+import PlotTraces from './plotTypes/PlotTraces';
+import PlotGranger from './plotTypes/PlotGranger';
+import PlotRatePSD from './plotTypes/PlotRatePSD';
+import PlotSpikeHist from './plotTypes/PlotSpikeHist';
+import PlotSpikeStats from './plotTypes/PlotSpikeStats';
+
+export default class NetPyNEPlot extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentName: props.name,
+    };
+  };
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({ currentName: nextProps.name });
+  };
+
+  render() {
+    switch (this.state.currentName) {
+      case "plotRaster":
+          var content = <PlotRaster />
+          break;
+      case "plotSpikeHist":
+          var content = <PlotSpikeHist />
+          break;
+      case "plotSpikeStats":
+          var content = <PlotSpikeStats />
+          break;
+      case "plotRatePSD":
+          var content = <PlotRatePSD />
+          break;
+      case "plotTraces":
+          var content = <PlotTraces />
+          break;
+      case "plotLFP":
+          var content = <PlotLFP />
+          break;
+      case "plotShape":
+          var content = <PlotShape />
+          break;
+      case "plotConn":
+          var content = <PlotConn />
+          break;
+      case "plot2Dnet":
+          var content = <Plot2Dnet />
+          break;
+      case "granger":
+          var content = <PlotGranger />
+          break;
+    };
+    
+    return content;
+  };
+};

--- a/components/definition/plots/NetPyNEPlotThumbnail.js
+++ b/components/definition/plots/NetPyNEPlotThumbnail.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+import IconButton from 'material-ui/IconButton';
+import FontIcon from 'material-ui/FontIcon';
+
+const hoverColor = '#66d2e2';
+const changeColor = 'rgb(0, 188, 212)';
+
+export default class NetPyNEPlotThumbnail extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  };
+
+  handleClick() {
+    this.props.handleClick(this.props.name);
+  };
+
+  render() {
+    return (
+      <IconButton
+        className={"gearThumbButton " + (this.props.selected ? "selectedGearButton" : "")}
+        onClick={this.handleClick}
+      >
+        <FontIcon color={changeColor} hoverColor={hoverColor} className="gpt-fullgear" />
+        <span className={"gearThumbLabel"}>{this.props.name}</span>
+      </IconButton>
+    );
+  };
+};

--- a/components/definition/plots/NetPyNEPlots.js
+++ b/components/definition/plots/NetPyNEPlots.js
@@ -1,0 +1,115 @@
+import React, { Component } from 'react';
+import IconMenu from 'material-ui/IconMenu';
+import Card, { CardHeader, CardText } from 'material-ui/Card';
+import Utils from '../../../Utils';
+import NetPyNEPlot from './NetPyNEPlot';
+import NetPyNENewPlot from './NetPyNENewPlot';
+import NetPyNEPlotThumbnail from './NetPyNEPlotThumbnail';
+
+export default class NetPyNEPlots extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedPlot: undefined,
+    };
+    this.selectPlot = this.selectPlot.bind(this);
+    this.handleNewPlot = this.handleNewPlot.bind(this);
+  };
+
+  selectPlot(plot) {
+    this.setState({ selectedPlot: plot });
+  };
+
+  handleNewPlot(plot) {
+    if (this.state.value!=undefined) {
+        var model = this.state.value;
+        model[plot] = true;
+    } else {
+        var model = {plot : true}
+    };
+    Utils
+      .sendPythonMessage("netpyne_geppetto.getAvailablePlots", [])
+      .then((response) => {
+        if (response.includes(plot)) {
+          if (plot=="plotLFP") {
+            var include = {
+              'electrodes': ['all']
+            }
+          } else if (plot=="plotShape") {
+            var include = {
+              'includePre': ['all'], 
+              'includePost': ['all']
+            }
+          } else if (plot=="granger") {
+            var include = {
+              'cells1': ['all'], 
+              'cells2': ['all']
+            }
+          } else {
+            var include = {
+              'include': ['all']
+            }
+          };
+          Utils.execPythonCommand("netpyne_geppetto.simConfig.analysis['" + plot + "'] = "+JSON.stringify(include));
+        }
+      });
+    this.setState({
+      value: model,
+      selectedPlot: plot
+    });
+  };
+  
+  shouldComponentUpdate(nextProps, nextState) {
+    var newItemCreated = false;
+    var selectionChanged = this.state.selectedPlot != nextState.selectedPlot;
+    if (this.state.value!=undefined) {
+      newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
+    };
+    return newItemCreated || selectionChanged;
+  };
+
+  render() {
+    var Plots = [];
+    for (var c in this.state.value) {
+      Plots.push(<NetPyNEPlotThumbnail name={c} key={c} selected={c == this.state.selectedPlot} handleClick={this.selectPlot} />);
+    };
+    if (this.state.selectedPlot ) {
+      var selectedPlot = <NetPyNEPlot name={this.state.selectedPlot} />;
+    };
+    
+    var content = (
+      <CardText className={"tabContainer"} expandable={true}>
+        <div className={"thumbnails"}>
+          <div className="breadcrumb">
+            <IconMenu style={{ float: 'left', marginTop: "12px", marginLeft: "18px" }}
+              iconButtonElement={
+                <NetPyNENewPlot handleClick={this.handleNewPlot} />
+              }
+              anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
+              targetOrigin={{ horizontal: 'left', vertical: 'top' }}
+            >
+            </IconMenu>
+          </div>
+          <div style={{ clear: "both" }}></div>
+          {Plots}
+        </div>
+        <div className={"details"}>
+          {selectedPlot}
+        </div>
+      </CardText>);
+      
+    return (
+      <Card style={{ clear: 'both' }}>
+        <CardHeader
+          title="Plot Configuration"
+          subtitle="Define rules to generate Plots (or do it later after instantiation or simulation)."
+          actAsExpander={true}
+          showExpandableButton={true}
+          id="Plots"
+        />
+        {content}
+      </Card>
+    );
+  };
+};

--- a/components/definition/plots/plotTypes/Plot2Dnet.js
+++ b/components/definition/plots/plotTypes/Plot2Dnet.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import ListComponent from '../../../general/List';
+import PyCheckBox from '../../../general/PyCheckBox';
+import NetPyNEField from '../../../general/NetPyNEField';
+import PySelectField from '../../../general/PySelectField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class Plot2Dnet extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  };
+  
+  render() {
+    var tags = "simConfig.analysis['plot2Dnet']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plot2Dnet.include" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['include']"} />
+        </NetPyNEField>
+        
+        <PySelectField
+          model={"simConfig.analysis['plot2Dnet']['view']"}
+          meta={"simConfig.analysis.plot2Dnet.view"}
+          items={["xy", "xz"]}
+        />
+        
+        <PyCheckBox
+          model={"simConfig.analysis['plot2Dnet']['showConns']"}
+          meta={"simConfig.analysis.plot2Dnet.showConns"}
+        />
+      </div>
+    );
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotConn.js
+++ b/components/definition/plots/plotTypes/PlotConn.js
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import ListComponent from '../../../general/List';
+import NetPyNEField from '../../../general/NetPyNEField';
+import PySelectField from '../../../general/PySelectField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class plotConn extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  };
+  
+  render() {
+    var tags = "simConfig.analysis['plotConn']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plotConn.include" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['include']"} />
+        </NetPyNEField>
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotConn']['feature']"}
+          meta={"simConfig.analysis.plotConn.feature"}
+          items={["weight", "delay", "numConns", "probability", "strength", "convergency", "divergency"]}
+        />
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotConn']['groupBy']"}
+          meta={"simConfig.analysis.plotConn.groupBy"}
+          items={["pop", "cell"]}
+        />
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotConn']['orderBy']"}
+          meta={"simConfig.analysis.plotConn.orderBy"}
+          items={["gid", "y", "ynorm"]}
+        />
+      </div>
+    );
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotGranger.js
+++ b/components/definition/plots/plotTypes/PlotGranger.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
+import ListComponent from '../../../general/List';
+import NetPyNEField from '../../../general/NetPyNEField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class PlotGranger extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  };
+  
+  render() {
+    var tags = "simConfig.analysis['granger']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.granger.cells1" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['cells1']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.granger.cells2" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['cells2']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.granger.spks1" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['spks1']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.granger.spks2" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['spks2']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.granger.label1" >
+          <PythonControlledTextField model={tags + "['label1']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.granger.label2" >
+          <PythonControlledTextField model={tags + "['label2']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.granger.timeRange" >
+          <PythonControlledTextField model={tags + "['timeRange']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.granger.binSize" >
+          <PythonControlledTextField model={tags + "['binSize']"} />
+        </NetPyNEField>
+      </div>
+    );
+    
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotLFP.js
+++ b/components/definition/plots/plotTypes/PlotLFP.js
@@ -1,0 +1,71 @@
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
+import ListComponent from '../../../general/List';
+import PyCheckBox from '../../../general/PyCheckBox';
+import NetPyNEField from '../../../general/NetPyNEField';
+import PySelectField from '../../../general/PySelectField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class PlotLFP extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      plots: '',
+    };
+  };
+    
+  render() {
+    var tags = "simConfig.analysis['plotLFP']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plotLFP.electrodes" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['electrodes']"} />
+        </NetPyNEField>
+        
+        <PySelectField 
+          model="simConfig.analysis['plotLFP']['plots']"
+          meta="simConfig.analysis.plotLFP.plots"
+          items={["timeSeries", "PSD", "timeFreq", "location"]}
+        />
+        
+        <NetPyNEField id="simConfig.analysis.plotLFP.timeRange" >
+          <PythonControlledTextField model={tags + "['timeRange']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotLFP.NFFT" >
+          <PythonControlledTextField model={tags + "['NFFT']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotLFP.noverlap" >
+          <PythonControlledTextField model={tags + "['noverlap']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotLFP.maxFreq" >
+          <PythonControlledTextField model={tags + "['maxFreq']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotLFP.nperseg" >
+          <PythonControlledTextField model={tags + "['nperseg']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotLFP.smooth" >
+          <PythonControlledTextField model={tags + "['smooth']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotLFP.separation" >
+          <PythonControlledTextField model={tags + "['separation']"}/>
+        </NetPyNEField>
+        
+        <PyCheckBox
+          model="simConfig.analysis['plotLFP']['includeAxon']"
+          meta="simConfig.analysis.plotLFP.includeAxon"
+        />     
+      </div>
+    );
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotRaster.js
+++ b/components/definition/plots/plotTypes/PlotRaster.js
@@ -1,0 +1,77 @@
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
+import ListComponent from '../../../general/List';
+import PyCheckBox from '../../../general/PyCheckBox';
+import NetPyNEField from '../../../general/NetPyNEField';
+import PySelectField from '../../../general/PySelectField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class PlotRaster extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      checked: false,
+    };
+    this.handleCheckChange = this.handleCheckChange.bind(this);
+  };
+  
+  handleCheckChange = (event, isCheck) => {
+    this.setState({Checked: isCheck})
+  };
+  
+  render() {
+    var tags = "simConfig.analysis['plotRaster']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plotRaster.include" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['include']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotRaster.timeRange" >
+          <PythonControlledTextField model={tags + "['timeRange']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotRaster.maxSpikes" >
+          <PythonControlledTextField model={tags + "['maxSpikes']"}/>
+        </NetPyNEField>
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotRaster']['orderBy']"}
+          meta={"simConfig.analysis.plotRaster.orderBy"}
+          items={["gid", "y", "ynorm"]}
+        />
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotRaster']['popRates']"}
+          meta={"simConfig.analysis.plotRaster.popRates"}
+          items={["legend", "overlay"]}
+        />
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotRaster']['spikeHist']"}
+          meta={"simConfig.analysis.plotRaster.spikeHist"}
+          items={["None", "overlay", "subplot"]}
+        />
+          
+        <NetPyNEField id="simConfig.analysis.plotRaster.spikeHistBin" >
+          <PythonControlledTextField model={tags + "['spikeHistBin']"}/>
+        </NetPyNEField>
+        
+        <PyCheckBox 
+          model={"simConfig.analysis['plotRaster']['orderInverse']"}
+          meta={"simConfig.analysis.plotRaster.orderInverse"}
+        />
+                
+        <PyCheckBox 
+          model={"simConfig.analysis['plotRaster']['syncLines']"}
+          meta={"simConfig.analysis.plotRaster.syncLines"}
+        />
+      </div>
+    );
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotRatePSD.js
+++ b/components/definition/plots/plotTypes/PlotRatePSD.js
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
+import ListComponent from '../../../general/List';
+import PyCheckBox from '../../../general/PyCheckBox'
+import NetPyNEField from '../../../general/NetPyNEField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class PlotRatePSD extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  };
+  
+  render() {
+    var tags = "simConfig.analysis['plotRatePSD']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plotRatePSD.include" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['include']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotRatePSD.timeRange" >
+          <PythonControlledTextField model={tags + "['timeRange']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotRatePSD.binSize" >
+          <PythonControlledTextField model={tags + "['binSize']"}/>
+        </NetPyNEField>
+
+        <NetPyNEField id="simConfig.analysis.plotRatePSD.maxFreq" >
+          <PythonControlledTextField model={tags + "['maxFreq']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotRatePSD.NFFT" >
+          <PythonControlledTextField model={tags + "['NFFT']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotRatePSD.noverlap" >
+          <PythonControlledTextField model={tags + "['noverlap']"}/>
+        </NetPyNEField>
+
+        <NetPyNEField id="simConfig.analysis.plotRatePSD.smooth" >
+          <PythonControlledTextField model={tags + "['smooth']"}/>
+        </NetPyNEField>
+        
+        <PyCheckBox
+          model={"simConfig.analysis['plotRatePSD']['overlay']"}
+          meta={"simConfig.analysis.plotRatePSD.overlay"}
+        />
+      </div>
+    );
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotShape.js
+++ b/components/definition/plots/plotTypes/PlotShape.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
+import ListComponent from '../../../general/List';
+import PyCheckBox from '../../../general/PyCheckBox';
+import NetPyNEField from '../../../general/NetPyNEField';
+import PySelectField from '../../../general/PySelectField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class PlotShape extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  };
+    
+  render() {
+    var tags = "simConfig.analysis['plotShape']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plotShape.includePre" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['includePre']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotShape.includePost" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['includePost']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotShape.synStyle" >
+          <PythonControlledTextField model={tags + "['synStyle']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotShape.dist" >
+          <PythonControlledTextField model={tags + "['dist']"}/>
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotShape.synSize" >
+          <PythonControlledTextField model={tags + "['synSize']"}/>
+        </NetPyNEField>
+        
+        <PySelectField
+         model={"simConfig.analysis['plotShape']['cvar']"}
+         meta={"simConfig.analysis.plotShape.cvar"}
+         items={["numSyns", "weightNorm"]}
+        />
+        
+        <NetPyNEField id="simConfig.analysis.plotShape.cvals" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['cvals']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotShape.bkgColor" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['bkgColor']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotShape.ivprops" >
+          <PythonControlledTextField model={tags + "['ivprops']"}/>
+        </NetPyNEField>
+
+        <PyCheckBox
+          model={"simConfig.analysis['plotShape']['iv']"}
+          meta={"simConfig.analysis.plotShape.iv"}
+        />
+        
+        <PyCheckBox
+          model={"simConfig.analysis['plotShape']['includeAxon']"}
+          meta={"simConfig.analysis.plotShape.includeAxon"}
+        />
+        
+        <PyCheckBox
+          model={"simConfig.analysis['plotShape']['showSyns']"}
+          meta={"simConfig.analysis.plotShape.showSyns"}
+        />
+        
+        <PyCheckBox
+          model={"simConfig.analysis['plotShape']['showElectrodes']"}
+          meta={"simConfig.analysis.plotShape.showElectrodes"}
+        />
+      </div>
+    );
+    
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotSpikeHist.js
+++ b/components/definition/plots/plotTypes/PlotSpikeHist.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
+import ListComponent from '../../../general/List';
+import PyCheckBox from '../../../general/PyCheckBox';
+import NetPyNEField from '../../../general/NetPyNEField';
+import PySelectField from '../../../general/PySelectField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class PlotSpikeHist extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  };
+    
+  render() {
+    var tags = "simConfig.analysis['plotSpikeHist']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plotSpikeHist.include" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['include']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotSpikeHist.timeRange" >
+          <PythonControlledTextField model={tags + "['timeRange']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotSpikeHist.binSize" >
+          <PythonControlledTextField model={tags + "['binSize']"}/>
+        </NetPyNEField>
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotSpikeHist']['graphType']"}
+          meta={"simConfig.analysis.plotSpikeHist.graphType"}
+          items={["line", "bar"]}
+        />
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotSpikeHist']['yaxis']"}
+          meta={"simConfig.analysis.plotSpikeHist.yaxis"}
+          items={["rate", "count"]}
+        />
+
+        <PyCheckBox 
+          model={"simConfig.analysis['plotSpikeHist']['overlay']"}
+          meta={"simConfig.analysis.plotSpikeHist.overlay"}
+        />
+    </div>
+    );
+    
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotSpikeStats.js
+++ b/components/definition/plots/plotTypes/PlotSpikeStats.js
@@ -1,0 +1,51 @@
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
+import ListComponent from '../../../general/List';
+import NetPyNEField from '../../../general/NetPyNEField';
+import PySelectField from '../../../general/PySelectField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class PlotSpikeStats extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  };
+    
+  render() {
+    var tags = "simConfig.analysis['plotSpikeStats']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plotSpikeStats.include" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['include']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotSpikeStats.timeRange" >
+          <PythonControlledTextField model={tags + "['timeRange']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotSpikeStats.popColors" >
+          <PythonControlledTextField model={tags + "['popColors']"}/>
+        </NetPyNEField>
+        
+        <PySelectField 
+          model={"simConfig.analysis['plotSpikeStats']['graphType']"}
+          meta={"simConfig.analysis.plotSpikeStats.graphType"}
+          items={["boxplot"]}
+        />
+          
+        <PySelectField 
+          model={"simConfig.analysis['plotSpikeStats']['stats']"}
+          meta={"simConfig.analysis.plotSpikeStats.stats"}
+          items={["rate", "isicv", "pairsync", "sync"]}
+        />        
+      </div>
+    );
+    
+    return content;
+  };
+};

--- a/components/definition/plots/plotTypes/PlotTraces.js
+++ b/components/definition/plots/plotTypes/PlotTraces.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+import TextField from 'material-ui/TextField';
+import ListComponent from '../../../general/List';
+import PyCheckBox from '../../../general/PyCheckBox';
+import NetPyNEField from '../../../general/NetPyNEField';
+import PySelectField from '../../../general/PySelectField';
+
+var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+
+export default class PlotTraces extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  };
+    
+  render() {
+    var tags = "simConfig.analysis['plotTraces']"
+    var content = (
+      <div>
+        <NetPyNEField id="simConfig.analysis.plotTraces.include" className="listStyle" >
+          <PythonControlledListComponent model={tags + "['include']"} />
+        </NetPyNEField>
+        
+        <NetPyNEField id="simConfig.analysis.plotTraces.timeRange" >
+          <PythonControlledTextField model={tags + "['timeRange']"} />
+        </NetPyNEField>
+        
+        <PySelectField 
+          model="simConfig.analysis['plotTraces']['oneFigPer']"
+          meta="simConfig.analysis.plotTraces.oneFigPer"
+          items={["cell", "traces"]}
+        />
+        
+        <PyCheckBox 
+          model="simConfig.analysis['plotTraces']['overlay']"
+          meta="simConfig.analysis.plotTraces.overlay"
+        />
+        
+        <PyCheckBox 
+          model="simConfig.analysis['plotTraces']['rerun']"
+          meta="simConfig.analysis.plotTraces.rerun"
+        />
+      </div>
+    );
+    
+    return content;
+  };
+};

--- a/components/general/NetPyNEField.js
+++ b/components/general/NetPyNEField.js
@@ -48,8 +48,11 @@ export default class NetPyNEField extends Component {
 
             var floatingLabelText = Utils.getMetadataField(this.props.id, "label");
             extraProps['label'] = floatingLabelText;
-            extraProps['floatingLabelText'] = floatingLabelText;
-
+            
+            if (child.type.name!="Checkbox") {
+              extraProps['floatingLabelText'] = floatingLabelText;
+            }
+            
             var dataSource = Utils.getMetadataField(this.props.id, "suggestions");
             if (dataSource != '') {
                 extraProps['dataSource'] = dataSource;

--- a/components/general/PyCheckBox.js
+++ b/components/general/PyCheckBox.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import Checkbox from 'material-ui/Checkbox';
+import NetPyNEField from './NetPyNEField';
+import Utils from '../../Utils';
+
+export default class PyCheckBox extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      checked: false,
+    };
+    this.updateCheck = this.updateCheck.bind(this);
+  };
+  
+  componentDidMount() {
+    Utils
+      .sendPythonMessage(this.props.model)
+      .then(response => {
+        if (response) this.setState({checked: response});
+      });
+  };
+  
+  updateCheck = (event, isCheck) => {
+    Utils.execPythonCommand("netpyne_geppetto." + this.props.model + " = " + (isCheck?'True':'False') );
+    this.setState({checked : isCheck});
+  };
+  
+  render() {
+    var content = (
+      <NetPyNEField id={this.props.meta} className={"netpyneCheckbox"} >
+        <Checkbox
+          checked={this.state.checked}
+          onCheck={this.updateCheck}
+        />
+      </NetPyNEField>
+    );
+    
+    return content;
+  };
+};

--- a/components/general/PySelectField.js
+++ b/components/general/PySelectField.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import SelectField from 'material-ui/SelectField';
+import NetPyNEField from './NetPyNEField';
+import MenuItem from 'material-ui/MenuItem';
+import Utils from '../../Utils';
+
+export default class PySelectField extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      currentValue: ''
+    };
+    this.handleCurrentValueChange = this.handleCurrentValueChange.bind(this);
+    this.createMenuItems = this.createMenuItems.bind(this);
+  };
+
+  componentDidMount () {
+    Utils
+      .sendPythonMessage(this.props.model)
+      .then(response => {
+        if (this.props.onChange!=undefined) this.props.onChange(response);
+        this.setState({currentValue: response});
+      });
+  };
+  
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.model!=this.props.model) {
+      Utils
+        .sendPythonMessage(nextProps.model)
+        .then(response => {
+          if (this.props.onChange!=undefined) this.props.onChange(response);
+          this.setState({currentValue: response});
+        });
+    };
+  };
+  
+  handleCurrentValueChange = (event, index, value) => {
+    Utils.execPythonCommand("netpyne_geppetto." + this.props.model + "= '" + value + "'");
+    if (this.props.onChange!=undefined) this.props.onChange(value);
+    this.setState({currentValue : value});
+  };
+  
+  createMenuItems = () => {
+    return this.props.items.map((name) => (
+      <MenuItem
+        key={name}
+        value={name}
+        primaryText={name}
+      />
+    ));
+  };
+  
+  render() {
+    var content = (
+      <div>
+        <NetPyNEField id={this.props.meta} className={"listStyle"} >
+          <SelectField onChange={this.handleCurrentValueChange} value={this.state.currentValue}>
+            {this.createMenuItems()}
+          </SelectField >
+        </NetPyNEField>
+      </div>
+    );
+    return content;
+  };
+};


### PR DESCRIPTION
this requires:
[https://github.com/MetaCell/NetPyNE-UI/pull/14](url) 
[https://github.com/Neurosim-lab/netpyne/pull/312](url)

The following PR incorporates functionality to define plot customization before hand.
It is useful in case users pretend to import models with the exact same plot definitions in order to reproduce results.

The parameters are saved as tags in simConfig.analysis and then passed as **kwards to netpyne function `sim.analysis()` when the user clicks the desired plot in the instantiated network and the customized plot appears as SVG.

It also creates 2 new components **PySelectField** and **PyCheckBox**, because **createPythonControlledControlWithPythonDataFetch** does not allow the use of predefined items and **PythonControlledCheckbox** is not working properly.

**NetPyNEField** has also been modified to skip warnings related to unnecessary metadata props passed to checkbox component