### PR TITLE
add full configuration options

### DIFF
--- a/components/definition/configuration/NetPyNESimConfig.js
+++ b/components/definition/configuration/NetPyNESimConfig.js
@@ -11,10 +11,13 @@ import FontIcon from 'material-ui/FontIcon';
 import ListComponent from '../../general/List';
 import NetPyNEField from '../../general/NetPyNEField';
 import Utils from '../../../Utils';
+import IconRecord from 'material-ui/svg-icons/av/fiber-manual-record';
+
 var PythonControlledCapability = require('../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
 var PythonControlledCheckbox = PythonControlledCapability.createPythonControlledControl(Checkbox);
 var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
+const RecordIcon = <IconRecord/>;
 
 export default class NetPyNESimConfig extends React.Component {
 
@@ -39,43 +42,59 @@ export default class NetPyNESimConfig extends React.Component {
     var content;
     if (this.state.sectionId == 'General') {
       content =
-        <div>
-          <NetPyNEField id="simConfig.seeds" >
-            <PythonControlledTextField model={"simConfig.seeds"} />
-          </NetPyNEField>
+        <div style={{ float: 'left', width: '100%' }}>
+          <div style={{ float: 'left', width: '45%' }}>
+            <NetPyNEField id="simConfig.seeds" >
+              <PythonControlledTextField model={"simConfig.seeds"} />
+            </NetPyNEField>
+            
+            <NetPyNEField id="simConfig.duration" >
+              <PythonControlledTextField model={"simConfig.duration"} />
+            </NetPyNEField>
+            
+            <NetPyNEField id="simConfig.hParams" >
+              <PythonControlledTextField model={"simConfig.hParams"} />
+            </NetPyNEField>
 
-          <NetPyNEField id="simConfig.addSynMechs" className={"netpyneCheckbox"} >
-            <PythonControlledCheckbox model={"simConfig.addSynMechs"} />
-          </NetPyNEField>
+            <NetPyNEField id="simConfig.dt" >
+              <PythonControlledTextField model={"simConfig.dt"} />
+            </NetPyNEField>
+          </div>
+          
+          <div style={{ float: 'right', width: '45%', marginTop:50}}>
+            <NetPyNEField id="simConfig.addSynMechs" className={"netpyneCheckbox"} >
+              <PythonControlledCheckbox model={"simConfig.addSynMechs"} />
+            </NetPyNEField>
 
-          <NetPyNEField id="simConfig.includeParamsLabel" className={"netpyneCheckbox"} >
-            <PythonControlledCheckbox model={"simConfig.includeParamsLabel"} />
-          </NetPyNEField>
+            <NetPyNEField id="simConfig.includeParamsLabel" className={"netpyneCheckbox"} >
+              <PythonControlledCheckbox model={"simConfig.includeParamsLabel"} />
+            </NetPyNEField>
 
-          <NetPyNEField id="simConfig.timing" className={"netpyneCheckbox"} >
-            <PythonControlledCheckbox model={"simConfig.timing"} />
-          </NetPyNEField>
+            <NetPyNEField id="simConfig.timing" className={"netpyneCheckbox"} >
+              <PythonControlledCheckbox model={"simConfig.timing"} />
+            </NetPyNEField>
 
-          <NetPyNEField id="simConfig.verbose" className={"netpyneCheckbox"} >
-            <PythonControlledCheckbox model={"simConfig.verbose"} />
-          </NetPyNEField>
+            <NetPyNEField id="simConfig.verbose" className={"netpyneCheckbox"} >
+              <PythonControlledCheckbox model={"simConfig.verbose"} />
+            </NetPyNEField>
+          </div>
         </div>
     }
     else if (this.state.sectionId == 'SaveConfiguration') {
       content =
         <div style={{ float: 'left', width: '100%' }}>
-          <div style={{ float: 'left', width: '50%' }}>
+          <div style={{ float: 'left', width: '30%' }}>
             <NetPyNEField id="simConfig.simLabel" >
               <PythonControlledTextField model={"simConfig.simLabel"} />
             </NetPyNEField>
-
+            
             {
               !window.isDocker &&
               <NetPyNEField id="simConfig.saveFolder" >
                 <PythonControlledTextField model={"simConfig.saveFolder"} />
               </NetPyNEField>
             }
-
+            
             <NetPyNEField id="simConfig.filename" >
               <PythonControlledTextField model={"simConfig.filename"} />
             </NetPyNEField>
@@ -84,23 +103,24 @@ export default class NetPyNESimConfig extends React.Component {
               <PythonControlledListComponent model={"simConfig.saveDataInclude"} />
             </NetPyNEField>
 
-            <NetPyNEField id="simConfig.timestampFilename" className={"netpyneCheckbox"} >
-              <PythonControlledCheckbox model={"simConfig.timestampFilename"} />
-            </NetPyNEField>
-
             <NetPyNEField id="simConfig.backupCfgFile" >
               <PythonControlledTextField model={"simConfig.backupCfgFile"} />
+            </NetPyNEField>
+          </div>
+          
+          <div style={{ float: 'right', width: '30%', marginTop:50, marginLeft:50}}>
+            <NetPyNEField id="simConfig.timestampFilename" className={"netpyneCheckbox"} >
+              <PythonControlledCheckbox model={"simConfig.timestampFilename"} />
             </NetPyNEField>
 
             <NetPyNEField id="simConfig.saveCellSecs" className={"netpyneCheckbox "}>
               <PythonControlledCheckbox model={"simConfig.saveCellSecs"} />
             </NetPyNEField>
-
+            
             <NetPyNEField id="simConfig.saveCellConns" className={"netpyneCheckbox"} >
               <PythonControlledCheckbox model={"simConfig.saveCellConns"} />
             </NetPyNEField>
-          </div>
-          <div style={{ float: 'right', width: '50%' }}>
+            
             <NetPyNEField id="simConfig.savePickle" className={"netpyneCheckbox"}>
               <PythonControlledCheckbox model={"simConfig.savePickle"} />
             </NetPyNEField>
@@ -112,7 +132,9 @@ export default class NetPyNESimConfig extends React.Component {
             <NetPyNEField id="simConfig.saveMat" className={"netpyneCheckbox"} >
               <PythonControlledCheckbox model={"simConfig.saveMat"} />
             </NetPyNEField>
-
+          </div>
+          
+          <div style={{ float: 'right', width: '30%', marginTop:50}}>
             <NetPyNEField id="simConfig.saveHDF5" className={"netpyneCheckbox"} >
               <PythonControlledCheckbox model={"simConfig.saveHDF5"} />
             </NetPyNEField>
@@ -120,40 +142,122 @@ export default class NetPyNESimConfig extends React.Component {
             <NetPyNEField id="simConfig.saveDpk" className={"netpyneCheckbox"} >
               <PythonControlledCheckbox model={"simConfig.saveDpk"} />
             </NetPyNEField>
-
+            
             <NetPyNEField id="simConfig.saveDat" className={"netpyneCheckbox"} >
               <PythonControlledCheckbox model={"simConfig.saveDat"} />
             </NetPyNEField>
-
+            
             <NetPyNEField id="simConfig.saveCSV" className={"netpyneCheckbox"} >
               <PythonControlledCheckbox model={"simConfig.saveCSV"} />
             </NetPyNEField>
+
+            <NetPyNEField id="simConfig.saveTxt" className={"netpyneCheckbox"} >
+              <PythonControlledCheckbox model={"simConfig.saveTxt"} />
+            </NetPyNEField>
+
+            <NetPyNEField id="simConfig.saveTiming" className={"netpyneCheckbox"} >
+              <PythonControlledCheckbox model={"simConfig.saveTiming"} />
+            </NetPyNEField>
           </div>
         </div>
-    }
-    else if (this.state.sectionId == 'ErrorChecking') {
+    } else if (this.state.sectionId == 'Record') {
+      content = 
+        <div style={{ float: 'left', width: '100%' }}>
+          <div style={{ float: 'left', width: '45%' }}>
+            <NetPyNEField id="simConfig.recordCells" className={"listStyle"} >
+            <PythonControlledListComponent model={"simConfig.recordCells"} />
+            </NetPyNEField>
+            
+            <NetPyNEField id="simConfig.recordLFP" >
+              <PythonControlledListComponent model={"simConfig.recordLFP"} />
+            </NetPyNEField>
+            
+            <NetPyNEField id="simConfig.saveLFPCells" className={"netpyneCheckbox"} style={{marginTop: 25}}>
+              <PythonControlledCheckbox model={"simConfig.saveLFPCells"} />
+            </NetPyNEField>
+            
+          </div>
+          <div style={{ float: 'right', width: '45%'}}>
+          
+            <NetPyNEField id="simConfig.recordTraces" >
+              <PythonControlledTextField model={"simConfig.recordTraces"} />
+            </NetPyNEField>
+
+            <NetPyNEField id="simConfig.recordStep" >
+              <PythonControlledTextField model={"simConfig.recordStep"} />
+            </NetPyNEField>
+                        
+            <NetPyNEField id="simConfig.recordStim" className={"netpyneCheckbox"} style={{marginTop: 25}}>
+              <PythonControlledCheckbox model={"simConfig.recordStim"} />
+            </NetPyNEField>
+          </div>
+        </div >
+    } else if (this.state.sectionId == 'ErrorChecking') {
       content =
-        <div>
+      <div style={{ float: 'left', width: '100%' }}>
+        <div style={{ float: 'left', width: '45%' }}>
           <NetPyNEField id="simConfig.checkErrors" className={"netpyneCheckbox"} >
             <PythonControlledCheckbox model={"simConfig.checkErrors"} />
           </NetPyNEField>
+        </div >
+        <div style={{ float: 'right', width: '45%'}}>
           <NetPyNEField id="simConfig.checkErrorsVerbose" className={"netpyneCheckbox"} >
             <PythonControlledCheckbox model={"simConfig.checkErrorsVerbose"} />
           </NetPyNEField>
         </div>
+      </div >
+        
     }
     else if (this.state.sectionId == 'Others') {
       content =
         <div>
-          <NetPyNEField id="simConfig.duration" >
-            <PythonControlledTextField model={"simConfig.duration"} />
+          <NetPyNEField id="simConfig.printRunTime"  >
+            <PythonControlledTextField model={"simConfig.printRunTime"} />
           </NetPyNEField>
+          
+          <div style={{ float: 'left', width: '100%' }}>
+            <div style={{ float: 'left', width: '45%', marginTop:50}}>  
+              <NetPyNEField id="simConfig.compactConnFormat" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.compactConnFormat"} />
+              </NetPyNEField>
 
-          <NetPyNEField id="simConfig.dt" >
-            <PythonControlledTextField model={"simConfig.dt"} />
-          </NetPyNEField>
-        </div >
-    }
+              <NetPyNEField id="simConfig.connRandomSecFromList" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.connRandomSecFromList"} />
+              </NetPyNEField>
+              
+              <NetPyNEField id="simConfig.printPopAvgRates" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.printPopAvgRates"} />
+              </NetPyNEField>
+
+              <NetPyNEField id="simConfig.printSynsAfterRule" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.printSynsAfterRule"} />
+              </NetPyNEField>
+              
+              <NetPyNEField id="simConfig.gatherOnlySimData" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.gatherOnlySimData"} />
+              </NetPyNEField>
+            </div>
+            
+            <div style={{ float: 'right', width: '45%', marginTop:50}}>  
+              <NetPyNEField id="simConfig.cache_efficient" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.cache_efficient"} />
+              </NetPyNEField>
+              
+              <NetPyNEField id="simConfig.cvode_active" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.cvode_active"} />
+              </NetPyNEField>
+               
+              <NetPyNEField id="simConfig.createNEURONObj" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.createNEURONObj"} />
+              </NetPyNEField>
+              
+              <NetPyNEField id="simConfig.createPyStruct" className={"netpyneCheckbox"} >
+                <PythonControlledCheckbox model={"simConfig.createPyStruct"} />
+              </NetPyNEField>
+            </div>
+          </div>
+        </div>
+    };
 
     return (
       <Card style={{ clear: 'both' }}>
@@ -169,9 +273,10 @@ export default class NetPyNESimConfig extends React.Component {
           <div>
             <BottomNavigation selectedIndex={this.state.selectedIndex}>
               <BottomNavigationItem key={'General'} label={'General'} icon={<FontIcon className={"fa fa-bars"} />} onClick={() => this.select(0, 'General')} />
-              <BottomNavigationItem key={'SaveConfiguration'} label={'Save Configuration'} icon={<FontIcon className={"fa fa-floppy-o"} />} onClick={() => this.select(1, 'SaveConfiguration')} />
-              <BottomNavigationItem key={'ErrorChecking'} label={'Error Checking'} icon={<FontIcon className={"fa fa-exclamation"} />} onClick={() => this.select(2, 'ErrorChecking')} />
-              <BottomNavigationItem key={'Others'} label={'Others'} icon={<FontIcon className={"fa fa-list"} />} onClick={() => this.select(3, 'Others')} />
+              <BottomNavigationItem key={'Record'} label={'Record'} icon={RecordIcon} onClick={() => this.select(1, 'Record')} />
+              <BottomNavigationItem key={'SaveConfiguration'} label={'Save Configuration'} icon={<FontIcon className={"fa fa-floppy-o"} />} onClick={() => this.select(2, 'SaveConfiguration')} />
+              <BottomNavigationItem key={'ErrorChecking'} label={'Error Checking'} icon={<FontIcon className={"fa fa-exclamation"} />} onClick={() => this.select(3, 'ErrorChecking')} />
+              <BottomNavigationItem key={'Others'} label={'Others'} icon={<FontIcon className={"fa fa-list"} />} onClick={() => this.select(4, 'Others')} />
             </BottomNavigation>
             <br />
             {content}


### PR DESCRIPTION
This PR requires: 
[https://github.com/Neurosim-lab/netpyne/pull/312/commits](url)

Some of the configuration options available in Netpyne were not displayed in the GUI. 

NOTE:
           The wrapper for checkbox has a bug. When you check the button, a True is send to the backend, but then if you close and open again the config tab, the checkbox appears unchecked. Although, the backend remains as True until a check-uncheck loop is completed.

I have a fix for that, but I am waiting for:
[https://github.com/MetaCell/geppetto-netpyne/pull/8](url) 
to be merge and use that checkbox component in configuration