### PR TITLE
Add netParams.importCellParams to cellRules

### DIFF
--- a/components/definition/cellRules/ImportCellParams.js
+++ b/components/definition/cellRules/ImportCellParams.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import Card from 'material-ui/Card/Card';
 import Checkbox from 'material-ui/Checkbox';
 import TextField from 'material-ui/TextField';
 import Dialog from 'material-ui/Dialog/Dialog';
-import CardText from 'material-ui/Card/CardText';
 import FlatButton from 'material-ui/FlatButton/FlatButton';
+import {Card, CardTitle, CardText} from 'material-ui/Card';
 import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
 import Utils from '../../../Utils';
 import NetPyNEField from '../../general/NetPyNEField';
@@ -38,13 +37,11 @@ export default class ImportCellParams extends React.Component {
 
   performAction = () => {
     // Show spinner
-    var message = GEPPETTO.Resources.IMPORTING_MODEL;
-    GEPPETTO.trigger(GEPPETTO.Events.Show_spinner, message);
+    GEPPETTO.trigger(GEPPETTO.Events.Show_spinner, GEPPETTO.Resources.IMPORTING_MODEL);
 
     // Import template
-    var action = 'netpyne_geppetto.importCellTemplate';
     Utils
-      .sendPythonMessage(action, [this.state])
+      .sendPythonMessage('netpyne_geppetto.importCellTemplate', [this.state])
       .then(() => {
         GEPPETTO.trigger(GEPPETTO.Events.Hide_spinner);
       });
@@ -61,7 +58,7 @@ export default class ImportCellParams extends React.Component {
       />,
       <RaisedButton
         primary
-        label={"import"}
+        label={"IMPORT"}
         onTouchTap={this.performAction}
       />
     ];
@@ -74,6 +71,7 @@ export default class ImportCellParams extends React.Component {
         actions={actions}
       >
         <Card style={{ padding: 10, float: 'left', width: '100%' }}>
+          <CardTitle title="Import Cell Template" subtitle="Python or Hoc files" />
           <CardText>
             <NetPyNEField id="netParams.importCellParams.fileName" className="netpyneFieldNoWidth">
               <TextField 
@@ -97,16 +95,16 @@ export default class ImportCellParams extends React.Component {
             </NetPyNEField>
             
             <div style={{width:'100%'}}>
-              <div style={{float:'left', width:'42%'}}>
+              <div style={{float:'left', width:'50%'}}>
                 <NetPyNEField id="netParams.importCellParams.importSynMechs" className="netpyneCheckbox">
-                  <Checkbox
+                  <Checkbox 
                     checked={this.state.importSynMechs}
                     onCheck={(event)=>this.updateCheck('importSynMechs')}
                   />
                 </NetPyNEField>
               </div>
               
-              <div style={{float:'left', width:'50%'}}>
+              <div style={{float:'right', width:'50%'}}>
                 <NetPyNEField id="netParams.importCellParams.compileMod" className="netpyneCheckbox">
                   <Checkbox
                     checked={this.state.compileMod}

--- a/components/definition/cellRules/ImportCellParams.js
+++ b/components/definition/cellRules/ImportCellParams.js
@@ -1,0 +1,123 @@
+import React from 'react';
+import Card from 'material-ui/Card/Card';
+import Checkbox from 'material-ui/Checkbox';
+import TextField from 'material-ui/TextField';
+import Dialog from 'material-ui/Dialog/Dialog';
+import CardText from 'material-ui/Card/CardText';
+import FlatButton from 'material-ui/FlatButton/FlatButton';
+import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
+import Utils from '../../../Utils';
+import NetPyNEField from '../../general/NetPyNEField';
+
+var PythonControlledCapability = require('../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+
+export default class ImportCellParams extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      label: props.name,
+      conds: {},
+      fileName: '',
+      cellName: '',
+      modFolder: '',
+      compileMod: false,
+      importSynMechs: false,
+    };
+    this.updateCheck = this.updateCheck.bind(this);
+    this.performAction = this.performAction.bind(this);
+  };
+  
+  updateCheck(name) {
+    this.setState((oldState) => {
+      return {
+        [name]: !oldState[name],
+      };
+    });
+  };
+
+  performAction = () => {
+    // Show spinner
+    var message = GEPPETTO.Resources.IMPORTING_MODEL;
+    GEPPETTO.trigger(GEPPETTO.Events.Show_spinner, message);
+
+    // Import template
+    var action = 'netpyne_geppetto.importCellTemplate';
+    Utils
+      .sendPythonMessage(action, [this.state])
+      .then(() => {
+        GEPPETTO.trigger(GEPPETTO.Events.Hide_spinner);
+      });
+    this.props.onRequestClose();
+      
+  };
+
+  render() {
+    const actions = [
+      <FlatButton
+        label={'CANCEL'}
+        onTouchTap={this.props.onRequestClose}
+        style={{ marginRight: 16 }}
+      />,
+      <RaisedButton
+        primary
+        label={"import"}
+        onTouchTap={this.performAction}
+      />
+    ];
+
+    return (
+      <Dialog
+        open={this.props.open}
+        onRequestClose={this.props.onRequestClose}
+        bodyStyle={{ overflow: 'auto' }}
+        actions={actions}
+      >
+        <Card style={{ padding: 10, float: 'left', width: '100%' }}>
+          <CardText>
+            <NetPyNEField id="netParams.importCellParams.fileName" className="netpyneFieldNoWidth">
+              <TextField 
+                value={this.state.fileName} 
+                onChange={(event) => this.setState({ fileName: event.target.value })}
+              />
+            </NetPyNEField>
+            
+            <NetPyNEField id="netParams.importCellParams.cellName" className="netpyneRightField">
+              <TextField
+                value={this.state.cellName} 
+                onChange={(event) => this.setState({ cellName: event.target.value })} 
+              />
+            </NetPyNEField>
+            
+            <NetPyNEField id="netParams.importCellParams.modFolder" className="netpyneRightField" >  
+              <TextField 
+                value={this.state.modFolder} 
+                onChange={(event) => this.setState({ modFolder: event.target.value })}
+              />
+            </NetPyNEField>
+            
+            <div style={{width:'100%'}}>
+              <div style={{float:'left', width:'42%'}}>
+                <NetPyNEField id="netParams.importCellParams.importSynMechs" className="netpyneCheckbox">
+                  <Checkbox
+                    checked={this.state.importSynMechs}
+                    onCheck={(event)=>this.updateCheck('importSynMechs')}
+                  />
+                </NetPyNEField>
+              </div>
+              
+              <div style={{float:'left', width:'50%'}}>
+                <NetPyNEField id="netParams.importCellParams.compileMod" className="netpyneCheckbox">
+                  <Checkbox
+                    checked={this.state.compileMod}
+                    onCheck={(event)=>this.updateCheck('compileMod')}
+                  />
+                </NetPyNEField>
+              </div>
+            </div>
+          </CardText>
+        </Card>
+      </Dialog>
+    );
+  };
+};

--- a/components/definition/cellRules/NetPyNECellRule.js
+++ b/components/definition/cellRules/NetPyNECellRule.js
@@ -1,28 +1,27 @@
 import React, { Component } from 'react';
-import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import TextField from 'material-ui/TextField';
-import Tooltip from 'material-ui/internal/Tooltip';
-import FlatButton from 'material-ui/FlatButton';
-import Toggle from 'material-ui/Toggle';
-import IconMenu from 'material-ui/IconMenu';
+import SelectField from 'material-ui/SelectField';
 import RaisedButton from 'material-ui/RaisedButton';
-import clone from 'lodash.clone';
 import Utils from '../../../Utils';
 import NetPyNEField from '../../general/NetPyNEField';
+import ImportCellParams from './ImportCellParams';
 
 var PythonControlledCapability = require('../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonMethodControlledSelectField = PythonControlledCapability.createPythonControlledControlWithPythonDataFetch(SelectField);
 
 export default class NetPyNECellRule extends React.Component {
 
   constructor(props) {
     super(props);
-    var _this = this;
     this.state = {
-      currentName: props.name
+      currentName: props.name,
+      importCellOpen: false
     };
-  }
+    this.closeImportCell = this.closeImportCell.bind(this);
+    this.openImportCell = this.openImportCell.bind(this);
+  };
 
   handleRenameChange = (event) => {
     var that = this;
@@ -48,7 +47,27 @@ export default class NetPyNECellRule extends React.Component {
   componentWillReceiveProps(nextProps) {
     this.setState({ currentName: nextProps.name});
   }
-
+  
+  closeImportCell = () => {
+    this.setState({ importCellOpen: false });
+  };
+  
+  openImportCell = () => {
+    this.setState({ importCellOpen: true });
+  };
+  
+  postProcessMenuItems(pythonData, selected) {
+    return pythonData.map((name) => (
+      <MenuItem
+        key={name}
+        insetChildren={true}
+        checked={selected.indexOf(name) > -1}
+        value={name}
+        primaryText={name}
+      />
+    ));
+  };
+  
   render() {
     var that = this;
     var content = (<div>
@@ -63,17 +82,32 @@ export default class NetPyNECellRule extends React.Component {
       />
 
       <br/>
-
-      <NetPyNEField id="netParams.cellParams.conds.cellModel" >
-        <PythonControlledTextField 
-        	model={"netParams.cellParams['" + this.props.name + "']['conds']['cellModel']"} 
-        	id="cellRuleCellModel"/>
+      
+      <NetPyNEField id={"netParams.cellParams.conds.pop"} >
+        <PythonMethodControlledSelectField
+          model={"netParams.cellParams['" + this.props.name + "']['conds']['pop']"}
+          method={"netpyne_geppetto.getAvailablePops"}
+          postProcessItems={this.postProcessMenuItems}
+          multiple={true}
+        />
       </NetPyNEField>
-
-      <NetPyNEField id="netParams.cellParams.conds.cellType" >
-        <PythonControlledTextField 
-        	model={"netParams.cellParams['" + this.props.name + "']['conds']['cellType']"} 
-        	id="cellRuleCellType"/>
+      
+      <NetPyNEField id={"netParams.cellParams.conds.cellType"} >
+        <PythonMethodControlledSelectField
+          model={"netParams.cellParams['" + this.props.name + "']['conds']['cellType']"}
+          method={"netpyne_geppetto.getAvailableCellTypes"}
+          postProcessItems={this.postProcessMenuItems}
+          multiple={true}
+        />
+      </NetPyNEField>
+            
+      <NetPyNEField id={"netParams.cellParams.conds.cellModel"} >
+        <PythonMethodControlledSelectField
+          model={"netParams.cellParams['" + this.props.name + "']['conds']['cellModel']"}
+          method={"netpyne_geppetto.getAvailableCellModels"}
+          postProcessItems={this.postProcessMenuItems}
+          multiple={true}
+        />
       </NetPyNEField>
       <br /><br />
 
@@ -83,6 +117,20 @@ export default class NetPyNECellRule extends React.Component {
         primary={true}
         onClick={() => that.props.selectPage("sections")}
       />
+      
+      <RaisedButton
+        style={{marginLeft:40}}
+        label="Import template"
+        labelPosition="before"
+        primary={true}
+        onClick={this.openImportCell}
+      />
+      
+      <ImportCellParams 
+        name={this.props.name}
+        open={this.state.importCellOpen} 
+        onRequestClose={this.closeImportCell}
+      />
     </div>);
 
     return (
@@ -90,5 +138,5 @@ export default class NetPyNECellRule extends React.Component {
         {content}
       </div>
     );
-  }
-}
+  };
+};

--- a/components/definition/cellRules/NetPyNECellRule.js
+++ b/components/definition/cellRules/NetPyNECellRule.js
@@ -19,8 +19,6 @@ export default class NetPyNECellRule extends React.Component {
       currentName: props.name,
       importCellOpen: false
     };
-    this.closeImportCell = this.closeImportCell.bind(this);
-    this.openImportCell = this.openImportCell.bind(this);
   };
 
   handleRenameChange = (event) => {
@@ -48,14 +46,6 @@ export default class NetPyNECellRule extends React.Component {
     this.setState({ currentName: nextProps.name});
   }
   
-  closeImportCell = () => {
-    this.setState({ importCellOpen: false });
-  };
-  
-  openImportCell = () => {
-    this.setState({ importCellOpen: true });
-  };
-  
   postProcessMenuItems(pythonData, selected) {
     return pythonData.map((name) => (
       <MenuItem
@@ -69,7 +59,6 @@ export default class NetPyNECellRule extends React.Component {
   };
   
   render() {
-    var that = this;
     var content = (<div>
 
       <TextField
@@ -85,7 +74,7 @@ export default class NetPyNECellRule extends React.Component {
       
       <NetPyNEField id={"netParams.cellParams.conds.pop"} >
         <PythonMethodControlledSelectField
-          model={"netParams.cellParams['" + this.props.name + "']['conds']['pop']"}
+          model={"netParams.cellParams['" + this.state.currentName + "']['conds']['pop']"}
           method={"netpyne_geppetto.getAvailablePops"}
           postProcessItems={this.postProcessMenuItems}
           multiple={true}
@@ -94,7 +83,7 @@ export default class NetPyNECellRule extends React.Component {
       
       <NetPyNEField id={"netParams.cellParams.conds.cellType"} >
         <PythonMethodControlledSelectField
-          model={"netParams.cellParams['" + this.props.name + "']['conds']['cellType']"}
+          model={"netParams.cellParams['" + this.state.currentName + "']['conds']['cellType']"}
           method={"netpyne_geppetto.getAvailableCellTypes"}
           postProcessItems={this.postProcessMenuItems}
           multiple={true}
@@ -103,7 +92,7 @@ export default class NetPyNECellRule extends React.Component {
             
       <NetPyNEField id={"netParams.cellParams.conds.cellModel"} >
         <PythonMethodControlledSelectField
-          model={"netParams.cellParams['" + this.props.name + "']['conds']['cellModel']"}
+          model={"netParams.cellParams['" + this.state.currentName + "']['conds']['cellModel']"}
           method={"netpyne_geppetto.getAvailableCellModels"}
           postProcessItems={this.postProcessMenuItems}
           multiple={true}
@@ -115,7 +104,7 @@ export default class NetPyNECellRule extends React.Component {
         label="Sections"
         labelPosition="before"
         primary={true}
-        onClick={() => that.props.selectPage("sections")}
+        onClick={() => this.props.selectPage("sections")}
       />
       
       <RaisedButton
@@ -123,13 +112,13 @@ export default class NetPyNECellRule extends React.Component {
         label="Import template"
         labelPosition="before"
         primary={true}
-        onClick={this.openImportCell}
+        onClick={() => this.setState({ importCellOpen: true })}
       />
       
       <ImportCellParams 
-        name={this.props.name}
+        name={this.state.currentName}
         open={this.state.importCellOpen} 
-        onRequestClose={this.closeImportCell}
+        onRequestClose={() => this.setState({ importCellOpen: false })}
       />
     </div>);
 


### PR DESCRIPTION
This requires:
https://github.com/Neurosim-lab/netpyne/pull/314
https://github.com/MetaCell/NetPyNE-UI/pull/17

Adding functionality to load .py or .hoc cell templates into cellRule tab.

Also changed **cellModel**, **cellType** and **Pop** from `PythonControlledTextField` to `pythonMethodControlledSelectField` (now that this component is available).