### PR TITLE
some Tabs like synMechParams were not showing the data after coming back from instantiation

### DIFF
--- a/components/definition/plots/NetPyNEPlots.js
+++ b/components/definition/plots/NetPyNEPlots.js
@@ -21,6 +21,7 @@ export default class NetPyNEPlots extends React.Component {
     super(props);
     this.state = {
       selectedPlot: undefined,
+      page: "main"
     };
     this.selectPlot = this.selectPlot.bind(this);
     this.handleNewPlot = this.handleNewPlot.bind(this);
@@ -72,10 +73,12 @@ export default class NetPyNEPlots extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     var newItemCreated = false;
     var selectionChanged = this.state.selectedPlot != nextState.selectedPlot;
+    var pageChanged = this.state.page != nextState.page;
+    var newModel = this.state.value == undefined;
     if (this.state.value != undefined) {
       newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
     };
-    return newItemCreated || selectionChanged;
+    return newModel || newItemCreated || selectionChanged || pageChanged;;
   };
 
   render() {

--- a/components/definition/stimulationSources/NetPyNEStimulationSources.js
+++ b/components/definition/stimulationSources/NetPyNEStimulationSources.js
@@ -12,6 +12,7 @@ export default class NetPyNEStimulationSources extends React.Component {
     super(props);
     this.state = {
       selectedStimulationSource: undefined,
+      page: "main"
     };
     this.selectStimulationSource = this.selectStimulationSource.bind(this);
     this.handleNewStimulationSource = this.handleNewStimulationSource.bind(this);
@@ -68,10 +69,12 @@ export default class NetPyNEStimulationSources extends React.Component {
     var itemRenamed = this.hasSelectedStimulationSourceBeenRenamed(this.state, nextState) != false;
     var newItemCreated = false;
     var selectionChanged = this.state.selectedStimulationSource != nextState.selectedStimulationSource;
+    var pageChanged = this.state.page != nextState.page;
+    var newModel = this.state.value == undefined;
     if (this.state.value!=undefined) {
       newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
     };
-    return newItemCreated || itemRenamed || selectionChanged;
+    return newModel || newItemCreated || itemRenamed || selectionChanged || pageChanged;
   };
 
   render() {

--- a/components/definition/stimulationTargets/NetPyNEStimulationTargets.js
+++ b/components/definition/stimulationTargets/NetPyNEStimulationTargets.js
@@ -12,6 +12,7 @@ export default class NetPyNEStimulationTargets extends React.Component {
     super(props);
     this.state = {
       selectedStimulationTarget: undefined,
+      page: "main"
     };
     this.selectStimulationTarget = this.selectStimulationTarget.bind(this);
     this.handleNewStimulationTarget = this.handleNewStimulationTarget.bind(this);
@@ -68,10 +69,12 @@ export default class NetPyNEStimulationTargets extends React.Component {
     var itemRenamed = this.hasSelectedStimulationTargetBeenRenamed(this.state, nextState) != false;
     var newItemCreated = false;
     var selectionChanged = this.state.selectedStimulationTarget != nextState.selectedStimulationTarget;
+    var pageChanged = this.state.page != nextState.page;
+    var newModel = this.state.value == undefined;
     if (this.state.value!=undefined) {
       newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
     };
-    return newItemCreated || itemRenamed || selectionChanged;
+    return newModel || newItemCreated || itemRenamed || selectionChanged || pageChanged;
   };
 
   render() {

--- a/components/definition/synapses/NetPyNESynapse.js
+++ b/components/definition/synapses/NetPyNESynapse.js
@@ -1,13 +1,7 @@
 import React, { Component } from 'react';
-import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import TextField from 'material-ui/TextField';
-import Tooltip from 'material-ui/internal/Tooltip';
-import FlatButton from 'material-ui/FlatButton';
-import Toggle from 'material-ui/Toggle';
-import IconMenu from 'material-ui/IconMenu';
-import RaisedButton from 'material-ui/RaisedButton';
-import clone from 'lodash.clone';
+import SelectField from 'material-ui/SelectField';
 import Utils from '../../../Utils';
 import NetPyNEField from '../../general/NetPyNEField';
 
@@ -20,10 +14,10 @@ export default class NetPyNESynapse extends React.Component {
     super(props);
     this.state = {
       currentName: props.name,
-      synMechMod: null
+      synMechMod: ''
     };
     this.synMechModOptions = [
-      { mod: 'Exp2Syn' }, 
+      { mod: 'Exp2Syn' },{mod: 'ExpSyn'} 
     ];
     this.handleSynMechModChange = this.handleSynMechModChange.bind(this);
   };
@@ -80,7 +74,42 @@ export default class NetPyNESynapse extends React.Component {
   };
 
   render() {
-    var content = (
+    if (this.state.synMechMod=='' || this.state.synMechMod==undefined) {
+      var content = <div/>
+    }
+    else { 
+      var content = (
+        <div>
+          <NetPyNEField id="netParams.synMechParams.tau1">
+            <PythonControlledTextField
+              model={"netParams.synMechParams['" + this.props.name + "']['tau1']"}
+            />
+          </NetPyNEField>
+          
+          {(this.state.synMechMod=="Exp2Syn")?<div>
+            <NetPyNEField id="netParams.synMechParams.tau2">
+              <PythonControlledTextField
+                model={"netParams.synMechParams['" + this.props.name + "']['tau2']"}
+              />
+            </NetPyNEField>
+            </div> : null}
+          
+          <NetPyNEField id="netParams.synMechParams.e" >
+            <PythonControlledTextField
+              model={"netParams.synMechParams['" + this.props.name + "']['e']"}
+            />
+          </NetPyNEField>
+          
+          <NetPyNEField id="netParams.synMechParams.i" >
+            <PythonControlledTextField
+              model={"netParams.synMechParams['" + this.props.name + "']['i']"}
+            />
+          </NetPyNEField>
+        </div>
+      )
+    }
+
+    return (
       <div>
         <TextField
           id={"synapseName"}
@@ -101,36 +130,9 @@ export default class NetPyNESynapse extends React.Component {
                 }) : null
             }
           </SelectField>
-        </NetPyNEField>  
-      </div>);
-      if (this.state.synMechMod=='Exp2Syn'){
-        var variableContent = (
-          <div>
-            <NetPyNEField id="netParams.synMechParams.tau1">
-              <PythonControlledTextField
-                model={"netParams.synMechParams['" + this.props.name + "']['tau1']"}
-              />
-            </NetPyNEField>
-            <NetPyNEField id="netParams.synMechParams.tau2">
-              <PythonControlledTextField
-                model={"netParams.synMechParams['" + this.props.name + "']['tau2']"}
-              />
-            </NetPyNEField>
-            <NetPyNEField id="netParams.synMechParams.e" >
-              <PythonControlledTextField
-                model={"netParams.synMechParams['" + this.props.name + "']['e']"}
-              />
-            </NetPyNEField>
-          </div>
-        )
-      } else {
-        var variableContent = <div/>
-      }
-    return (
-      <div>
-        {content}
-        {variableContent}
+        </NetPyNEField>
+        {content} 
       </div>
     );
-  }
-}
+  };
+};

--- a/components/definition/synapses/NetPyNESynapses.js
+++ b/components/definition/synapses/NetPyNESynapses.js
@@ -12,6 +12,7 @@ export default class NetPyNESynapses extends React.Component {
     super(props);
     this.state = {
       selectedSynapse: undefined,
+      page: "main"
     };
     this.selectSynapse = this.selectSynapse.bind(this);
     this.handleNewSynapse = this.handleNewSynapse.bind(this);
@@ -68,10 +69,12 @@ export default class NetPyNESynapses extends React.Component {
     var itemRenamed = this.hasSelectedSynapseBeenRenamed(this.state, nextState) != false;
     var newItemCreated = false;
     var selectionChanged = this.state.selectedSynapse != nextState.selectedSynapse;
+    var pageChanged = this.state.page != nextState.page;
+    var newModel = this.state.value == undefined;
     if (this.state.value != undefined) {
       newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
     };
-    return newItemCreated || itemRenamed || selectionChanged;
+    return newModel || newItemCreated || itemRenamed || selectionChanged || pageChanged;
   };
 
   render() {


### PR DESCRIPTION
Some tabs like **SynMechParams** seemed empty after coming back from network instantiation.
A minor modification to **ShouldComponentUpdate** fixed it.

Also added a second option for synapses. Now we have **Exp2Syn** and **ExpSyn** but it is basically the same, so I put everything together 