### PR TITLE
fix type format error

### DIFF
--- a/components/definition/connectivity/NetPyNEConnectivityRule.js
+++ b/components/definition/connectivity/NetPyNEConnectivityRule.js
@@ -1,13 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import TextField from 'material-ui/TextField';
-import Tooltip from 'material-ui/internal/Tooltip';
-import FlatButton from 'material-ui/FlatButton';
-import Toggle from 'material-ui/Toggle';
-import IconMenu from 'material-ui/IconMenu';
-import RaisedButton from 'material-ui/RaisedButton';
-import clone from 'lodash.clone';
 import Utils from '../../../Utils';
 import FontIcon from 'material-ui/FontIcon';
 import CardText from 'material-ui/Card';

--- a/components/definition/plots/plotTypes/PlotSpikeStats.js
+++ b/components/definition/plots/plotTypes/PlotSpikeStats.js
@@ -29,8 +29,8 @@ export default class PlotSpikeStats extends React.Component {
         <TimeRange model={tag + "['timeRange']"} />
       </NetPyNEField>
       
-      <NetPyNEField id="simConfig.analysis.plotSpikeStats.popColors" >
-        <PythonControlledTextField model={tag + "['popColors']"}/>
+      <NetPyNEField id="simConfig.analysis.plotSpikeStats.popColors" className="listStyle">
+        <PythonControlledListComponent model={tag + "['popColors']"}/>
       </NetPyNEField>
       
       <NetPyNEField id="simConfig.analysis.plotSpikeStats.graphType" className="listStyle" >
@@ -39,7 +39,7 @@ export default class PlotSpikeStats extends React.Component {
       
       <NetPyNEField id="simConfig.analysis.plotSpikeStats.stats" className="listStyle" >
         <PythonControlledSelectField model={tag + "['stats']"} />
-      </NetPyNEField>      
+      </NetPyNEField>
     </div>
   };
 };

--- a/components/general/List.js
+++ b/components/general/List.js
@@ -142,6 +142,9 @@ export default class ListComponent extends Component {
                 return JSON.parse(value);
             }
             else {
+                if ( !Array.isArray(value) ){
+                    value = [value];
+                }
                 return value.map((child, i) => {
                     return (typeof child == 'string') ? child : JSON.stringify(child);
                 });

--- a/components/general/NetPyNEField.js
+++ b/components/general/NetPyNEField.js
@@ -85,22 +85,22 @@ export default class NetPyNEField extends Component {
 
         const childWithProp = React.Children.map(this.props.children, (child) => {
             var extraProps = {}
+            
+            if (child.type.name != "SelectField") {
+                extraProps['validate'] = this.setErrorMessage;
+                extraProps['prePythonSyncProcessing'] = this.prePythonSyncProcessing;
 
-            extraProps['validate'] = this.setErrorMessage;
-            extraProps['prePythonSyncProcessing'] = this.prePythonSyncProcessing;
-
+                var dataSource = Utils.getMetadataField(this.props.id, "suggestions");
+                if (dataSource != '') {
+                    extraProps['dataSource'] = dataSource;
+                }
+            }
+            
             var floatingLabelText = Utils.getMetadataField(this.props.id, "label");
             extraProps['label'] = floatingLabelText;
 
             if (child.type.name != "Checkbox") {
                 extraProps['floatingLabelText'] = floatingLabelText;
-            }
-
-            if (child.type.name != "SelectField") {
-                var dataSource = Utils.getMetadataField(this.props.id, "suggestions");
-                if (dataSource != '') {
-                    extraProps['dataSource'] = dataSource;
-                }
             }
 
             var type = Utils.getHTMLType(this.props.id);

--- a/components/general/NetPyNEField.js
+++ b/components/general/NetPyNEField.js
@@ -75,6 +75,11 @@ export default class NetPyNEField extends Component {
             if (hintText != '') {
                 extraProps['hintText'] = hintText;
             }
+            
+            var default_value = Utils.getMetadataField(this.props.id, "default");
+            if (default_value != '') {
+                extraProps['default'] = default_value;
+            }
 
             var options = Utils.getMetadataField(this.props.id, "options");
             if (options) {

--- a/components/general/NetPyNEField.js
+++ b/components/general/NetPyNEField.js
@@ -21,7 +21,46 @@ export default class NetPyNEField extends Component {
         this.setState({ openHelp: false });
     };
 
+    setErrorMessage(value) {
+        return new Promise((resolve, reject) => {
+            if (this.realType == 'func') {
+                if (value != "" && value != undefined) {
+                    Utils.sendPythonMessage('netpyne_geppetto.validateFunction', [value]).then((response) => {
+                        if (!response) {
+                            resolve({ errorMsg: 'Not a valid function' })
+                        }
+                        else {
+                            resolve({ errorMsg: '' })
+                        }
+                    });
+                }
+                else {
+                    resolve({ errorMsg: '' })
+                }
+            }
+            else if (this.realType == 'float') {
+                if (isNaN(value)) {
+                    resolve({ errorMsg: 'Only float allowed' })
+                }
+                else {
+                    resolve({ errorMsg: '' })
+                }
+            }
+        }
+        );
+    };
 
+    prePythonSyncProcessing(value){
+        if (value == '') {
+            if (this.default != undefined) {
+                return this.default;
+            }
+            else if (!this.model.split(".")[0].startsWith('simConfig') || this.model.split(".")[1].startsWith('analysis')) {
+                Utils.execPythonCommand('del netpyne_geppetto.' + this.model)
+            }
+        }
+        return value;
+    }
 
     render() {
         var help = Utils.getMetadataField(this.props.id, "help");
@@ -47,18 +86,21 @@ export default class NetPyNEField extends Component {
         const childWithProp = React.Children.map(this.props.children, (child) => {
             var extraProps = {}
 
+            extraProps['validate'] = this.setErrorMessage;
+            extraProps['prePythonSyncProcessing'] = this.prePythonSyncProcessing;
+
             var floatingLabelText = Utils.getMetadataField(this.props.id, "label");
             extraProps['label'] = floatingLabelText;
 
             if (child.type.name != "Checkbox") {
                 extraProps['floatingLabelText'] = floatingLabelText;
             }
-            
+
             if (child.type.name != "SelectField") {
-              var dataSource = Utils.getMetadataField(this.props.id, "suggestions");
-              if (dataSource != '') {
-                  extraProps['dataSource'] = dataSource;
-              }
+                var dataSource = Utils.getMetadataField(this.props.id, "suggestions");
+                if (dataSource != '') {
+                    extraProps['dataSource'] = dataSource;
+                }
             }
 
             var type = Utils.getHTMLType(this.props.id);
@@ -75,7 +117,7 @@ export default class NetPyNEField extends Component {
             if (hintText != '') {
                 extraProps['hintText'] = hintText;
             }
-            
+
             var default_value = Utils.getMetadataField(this.props.id, "default");
             if (default_value != '') {
                 extraProps['default'] = default_value;


### PR DESCRIPTION
this requires: 
- https://github.com/openworm/org.geppetto.frontend/pull/816
- https://github.com/Neurosim-lab/netpyne/pull/333

this will be needed for CNS. Basically it deals with:

- float fields been filled up with text,
- fields that end up with a value equal to an empty string,
- fields that must contain a default value for netpyne to work.

I'm adding a extra prop "default" in metadata to reset the values that can not be left empty in order for the simulation to run. (simConfig.duration, simConfig.dt) 

### To test this PR:

- try to enter a string in a textfield (an alert will appear)
- fill a field with some value and then check with print(netpyne_geppetto.netParams.popParams['cellType']). the value that you entered. Then proceed to delete the field and type the previous command again. (the key should not appear anymore)
- go to configuration tab and try to delete the duration of the simulation (this field must contain a value in order for netpyne to simulate the network)
- Non of the keys in netpyne_geppetto.simConfig should be deleted because they are required for netpyne to simulate the network, so this PR also take cares of that by checking if this.props.model contains the word simConfig (this rule does not apply for simConfig.analysis which could be deleted)