### PR TITLE
delete default values when creating rules

### DIFF
--- a/components/definition/connectivity/NetPyNEConnectivityRule.js
+++ b/components/definition/connectivity/NetPyNEConnectivityRule.js
@@ -105,7 +105,7 @@ export default class NetPyNEConnectivityRule extends React.Component {
               model={"netParams.connParams['" + this.props.name + "']['synMech']"}
               method={"netpyne_geppetto.getAvailableSynMech"}
               postProcessItems={this.postProcessMenuItems}
-              multiple={true}
+              multiple={false}
             />
           </NetPyNEField>
           

--- a/components/definition/connectivity/NetPyNEConnectivityRule.js
+++ b/components/definition/connectivity/NetPyNEConnectivityRule.js
@@ -104,23 +104,24 @@ export default class NetPyNEConnectivityRule extends React.Component {
             <PythonMethodControlledSelectField
               model={"netParams.connParams['" + this.props.name + "']['synMech']"}
               method={"netpyne_geppetto.getAvailableSynMech"}
-              postProcessItems={this.postProcessMenuItems}
-              multiple={false}
+              postProcessItems={(pythonData, selected) => {
+                return pythonData.map((name) => (<MenuItem key={name} value={name} primaryText={name} />));
+              }}
             />
           </NetPyNEField>
-          
+
           <NetPyNEField id="netParams.connParams.convergence" >
             <PythonControlledTextField
               model={"netParams.connParams['" + this.props.name + "']['convergence']"}
             />
           </NetPyNEField>
-          
+
           <NetPyNEField id="netParams.connParams.divergence" >
             <PythonControlledTextField
               model={"netParams.connParams['" + this.props.name + "']['divergence']"}
             />
           </NetPyNEField>
-          
+
           <NetPyNEField id="netParams.connParams.probability" >
             <PythonControlledTextField
               model={"netParams.connParams['" + this.props.name + "']['probability']"}
@@ -179,37 +180,37 @@ export default class NetPyNEConnectivityRule extends React.Component {
             multiple={true}
           />
         </NetPyNEField>
-        
-        <NetPyNECoordsRange 
-          name={this.props.name} 
+
+        <NetPyNECoordsRange
+          name={this.props.name}
           model={'netParams.connParams'}
           conds={'preConds'}
           items={[
-            {value: 'x', label:'absolute'}, 
-            {value: 'xnorm', label:'normalized'}
+            { value: 'x', label: 'absolute' },
+            { value: 'xnorm', label: 'normalized' }
           ]}
         />
 
-        <NetPyNECoordsRange 
-          name={this.props.name} 
+        <NetPyNECoordsRange
+          name={this.props.name}
           model={'netParams.connParams'}
           conds={'preConds'}
           items={[
-            {value: 'y', label:'absolute'}, 
-            {value: 'ynorm', label:'normalized'}
+            { value: 'y', label: 'absolute' },
+            { value: 'ynorm', label: 'normalized' }
           ]}
         />
 
-        <NetPyNECoordsRange 
-          name={this.props.name} 
+        <NetPyNECoordsRange
+          name={this.props.name}
           model={'netParams.connParams'}
           conds={'preConds'}
           items={[
-            {value: 'z', label:'absolute'}, 
-            {value: 'znorm', label:'normalized'}
+            { value: 'z', label: 'absolute' },
+            { value: 'znorm', label: 'normalized' }
           ]}
         />
-      
+
       </div>
     }
     else if (this.state.sectionId == "Post Conditions") {
@@ -238,37 +239,37 @@ export default class NetPyNEConnectivityRule extends React.Component {
             multiple={true}
           />
         </NetPyNEField>
-        
-        <NetPyNECoordsRange 
-          name={this.props.name} 
+
+        <NetPyNECoordsRange
+          name={this.props.name}
           model={'netParams.connParams'}
           conds={'postConds'}
           items={[
-            {value: 'x', label:'absolute'}, 
-            {value: 'xnorm', label:'normalized'}
+            { value: 'x', label: 'absolute' },
+            { value: 'xnorm', label: 'normalized' }
           ]}
         />
 
-        <NetPyNECoordsRange 
-          name={this.props.name} 
+        <NetPyNECoordsRange
+          name={this.props.name}
           model={'netParams.connParams'}
           conds={'postConds'}
           items={[
-            {value: 'y', label:'absolute'}, 
-            {value: 'ynorm', label:'normalized'}
+            { value: 'y', label: 'absolute' },
+            { value: 'ynorm', label: 'normalized' }
           ]}
         />
 
-        <NetPyNECoordsRange 
-          name={this.props.name} 
+        <NetPyNECoordsRange
+          name={this.props.name}
           model={'netParams.connParams'}
           conds={'postConds'}
           items={[
-            {value: 'z', label:'absolute'}, 
-            {value: 'znorm', label:'normalized'}
+            { value: 'z', label: 'absolute' },
+            { value: 'znorm', label: 'normalized' }
           ]}
         />
-        
+
       </div>
     }
 

--- a/components/definition/connectivity/NetPyNEConnectivityRules.js
+++ b/components/definition/connectivity/NetPyNEConnectivityRules.js
@@ -41,12 +41,7 @@ export default class NetPyNEConnectivityRules extends React.Component {
     var defaultConnectivityRules = { 
       'ConnectivityRule': {
         'preConds': {},
-        'postConds': {},
-        'synMech': [],  
-        'synsPerConn': 0,
-        'weight': 0,
-        'delay': [],  
-        'loc': []
+        'postConds': {}
       }
     };
     // Get Key and Value

--- a/components/definition/stimulationSources/NetPyNEStimulationSources.js
+++ b/components/definition/stimulationSources/NetPyNEStimulationSources.js
@@ -25,7 +25,7 @@ export default class NetPyNEStimulationSources extends React.Component {
   };
 
   handleNewStimulationSource() {
-    var defaultStimulationSources = { 'stim_source ': { 'type': '', 'del': 0, 'dur': 0, 'amp': ''}};
+    var defaultStimulationSources = { 'stim_source ': { 'type': ''}};
     var key = Object.keys(defaultStimulationSources)[0];
     var value = defaultStimulationSources[key];
     var model = this.state.value;

--- a/components/definition/stimulationTargets/NetPyNEStimulationTarget.js
+++ b/components/definition/stimulationTargets/NetPyNEStimulationTarget.js
@@ -114,7 +114,6 @@ export default class NetPyNEStimulationTarget extends React.Component {
               model={"netParams.stimTargetParams['" + this.props.name + "']['source']"}
               method={"netpyne_geppetto.getAvailableStimSources"}
               postProcessItems={this.postProcessMenuItems}
-              multiple={false}
             />
           </NetPyNEField>
           
@@ -139,7 +138,6 @@ export default class NetPyNEStimulationTarget extends React.Component {
               model={"netParams.stimTargetParams['" + this.props.name + "']['synMech']"}
               method={"netpyne_geppetto.getAvailableSynMech"}
               postProcessItems={this.postProcessMenuItems4SynMech}
-              multiple={false}
             />
           </NetPyNEField>
           

--- a/components/definition/stimulationTargets/NetPyNEStimulationTargets.js
+++ b/components/definition/stimulationTargets/NetPyNEStimulationTargets.js
@@ -27,7 +27,7 @@ export default class NetPyNEStimulationTargets extends React.Component {
   };
 
   handleNewStimulationTarget() {
-    var defaultStimulationTargets = { 'stim_target ': {'source': '', 'sec':'', 'loc': 0, 'conds': {}}};
+    var defaultStimulationTargets = { 'stim_target ': {'source': '', 'conds': {}}};
     var key = Object.keys(defaultStimulationTargets)[0];
     var value = defaultStimulationTargets[key];
     var model = this.state.value;

--- a/components/definition/synapses/NetPyNESynapse.js
+++ b/components/definition/synapses/NetPyNESynapse.js
@@ -17,7 +17,7 @@ export default class NetPyNESynapse extends React.Component {
       synMechMod: ''
     };
     this.synMechModOptions = [
-      { mod: 'Exp2Syn' },{mod: 'ExpSyn'} 
+      { mod: 'Exp2Syn' }, {mod: 'ExpSyn'} 
     ];
     this.handleSynMechModChange = this.handleSynMechModChange.bind(this);
   };
@@ -62,7 +62,7 @@ export default class NetPyNESynapse extends React.Component {
   updateLayout() {
     const getMod = (value) => {
       Utils
-        .sendPythonMessage("'" + value + "' in netParams.synMechParams['" + this.state.currentName + "']['mod']")
+        .sendPythonMessage("'" + value + "' == netParams.synMechParams['" + this.state.currentName + "']['mod']")
         .then((response) => { if (response) {this.setState({synMechMod: value})}});
     };
     this.synMechModOptions.forEach((option) => { getMod(option.mod) });

--- a/components/definition/synapses/NetPyNESynapses.js
+++ b/components/definition/synapses/NetPyNESynapses.js
@@ -26,7 +26,7 @@ export default class NetPyNESynapses extends React.Component {
   };
 
   handleNewSynapse() {
-    var defaultSynapses = {'Synapse': {'mod': '', 'tau1': 0, 'tau2': 0, 'e': 0}};
+    var defaultSynapses = {'Synapse': {'mod': ''}};
     var key = Object.keys(defaultSynapses)[0];
     var value = defaultSynapses[key];
     var model = this.state.value;


### PR DESCRIPTION
This is required for CNS.

@tarelli it was what we talked today about some fields like location and syn weight going to 0.

I also saw that we were using multi=true for the synaptic model in connection, but it only allows 1 value, so I set it equal to false