### PR TITLE
remove warning when opening importCell dialog box

### DIFF
--- a/components/definition/stimulationSources/NetPyNEStimulationSource.js
+++ b/components/definition/stimulationSources/NetPyNEStimulationSource.js
@@ -179,6 +179,12 @@ export default class NetPyNEStimulationSource extends React.Component {
     } else if (this.state.sourceType == 'NetStim') {
       var variableContent = (
         <div>
+          <NetPyNEField id="netParams.stimSourceParams.rate">
+            <PythonControlledTextField
+              model={"netParams.stimSourceParams['" + this.props.name + "']['rate']"}
+            />
+          </NetPyNEField>
+          
           <NetPyNEField id="netParams.stimSourceParams.interval">
             <PythonControlledTextField
               model={"netParams.stimSourceParams['" + this.props.name + "']['interval']"}

--- a/components/general/NetPyNEField.js
+++ b/components/general/NetPyNEField.js
@@ -87,9 +87,6 @@ export default class NetPyNEField extends Component {
             var extraProps = {}
             
             if (child.type.name != "SelectField" && child.type.name != 'PythonControlledControlWithPythonDataFetch') {
-                extraProps['validate'] = this.setErrorMessage;
-                extraProps['prePythonSyncProcessing'] = this.prePythonSyncProcessing;
-
                 var dataSource = Utils.getMetadataField(this.props.id, "suggestions");
                 if (dataSource != '') {
                     extraProps['dataSource'] = dataSource;
@@ -109,6 +106,8 @@ export default class NetPyNEField extends Component {
             }
 
             if (child.type.name == "PythonControlledControl") {
+                extraProps['validate'] = this.setErrorMessage;
+                extraProps['prePythonSyncProcessing'] = this.prePythonSyncProcessing;
                 var realType = Utils.getMetadataField(this.props.id, "type");
                 extraProps['realType'] = realType;
             }


### PR DESCRIPTION
the properties **validate** & **prePythonSyncProcessing** should only be passed to **PythonControlledControl** because this is the only component that makes something with these props.

reproduce: 
- go to cellRule
- create new cell rule
- click import template
- the warning about this two will be raised

------------------------------
**NetStim** was missing rate parameter