### PR TITLE
Generate script

### DIFF
--- a/components/settings/Settings.js
+++ b/components/settings/Settings.js
@@ -4,7 +4,9 @@ import FlatButton from 'material-ui/FlatButton/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
 import {Card, CardHeader, CardText} from 'material-ui/Card';
 import {Tabs, Tab } from 'material-ui/Tabs';
+import MenuItem from 'material-ui/MenuItem';
 import TextField from 'material-ui/TextField';
+import SelectField from 'material-ui/SelectField';
 import Checkbox from 'material-ui/Checkbox';
 import Utils from '../../Utils';
 import FileBrowser from '../general/FileBrowser';
@@ -30,7 +32,8 @@ const SettingsDialog = React.createClass({
             exploreOnlyDirs: false,
             errorMessage: undefined,
             errorDetails: undefined,
-            scriptName: 'script_output'
+            scriptName: 'script_output',
+            exportFormat: "json"
         };
     },
 
@@ -46,6 +49,10 @@ const SettingsDialog = React.createClass({
 
     onChangeTab(value) {
         this.setState({ currentTab: value });
+    },
+    
+    onChange(event, index, value) {
+        this.setState({exportFormat: value})
     },
 
     processError(parsedResponse) {
@@ -64,11 +71,12 @@ const SettingsDialog = React.createClass({
             var message = GEPPETTO.Resources.IMPORTING_MODEL;
         }
         else if (this.state.currentTab == "export") {
-            var action = 'netpyne_geppetto.exportModel';
-            var message = GEPPETTO.Resources.EXPORTING_MODEL;
-        }
-        else {
-            var action = 'netpyne_geppetto.generateScript';
+            if (this.state.exportFormat== "json") {
+                var action = 'netpyne_geppetto.exportModel';
+            } 
+            else {
+                var action = 'netpyne_geppetto.generateScript';
+            }
             var message = GEPPETTO.Resources.EXPORTING_MODEL;
         }
 
@@ -139,7 +147,7 @@ const SettingsDialog = React.createClass({
                     cancelAction,
                     <RaisedButton
                         primary
-                        label={this.state.currentTab == "import" ? 'Import' : this.state.currentTab== 'Export'? 'Export': 'To script'}
+                        label={this.state.currentTab == "import" ? 'Import' : 'Export'}
                         onTouchTap={this.performAction}
                     />
                 ];
@@ -181,20 +189,29 @@ const SettingsDialog = React.createClass({
                     </Tab>
 
                     <Tab value="export" label={'Export'}>
-                        <div style={{ padding: 20 }}>
-                            Click on export to download the model as a json fle. File will be stored in the path specified in Configuration > Save Configuration > File Name.
-                        </div>
-                    </Tab>
-                    
-                    <Tab value="script" label={'To script'}>
                         <Card style={{ padding: 10, float: 'left', width: '100%' }}>
-                            <CardHeader
-                                title="Save your work as NetPyNE script."
-                                subtitle="The file will be saved in the current working directory (where you initialized NetPyNE-UI)"
-                            />
-                            <CardText>
-                                <TextField className="netpyneField" floatingLabelText="File name" value={this.state.scriptName} onChange={(event) => this.setState({ scriptName: event.target.value })} />
-                            </CardText>
+                            <SelectField
+                                style={{marginLeft: 20}}
+                                floatingLabelText="format"
+                                value={this.state.exportFormat}
+                                onChange={this.onChange}
+                            >
+                                <MenuItem value={"json"} primaryText="JSON" />
+                                <MenuItem value={"netpyne script"} primaryText="NetPyNE script" />
+                            </SelectField>
+                            {this.state.exportFormat=='json'?
+                                <CardHeader
+                                    title="Click on export to download the model as a json fle."
+                                    subtitle="File will be stored in the path specified in Configuration > Save Configuration > File Name."
+                                />:<div>
+                                <CardHeader
+                                    title="Save your work as NetPyNE script."
+                                    subtitle="The file will be saved in the current working directory (where you initialized NetPyNE-UI)"
+                                />
+                                <CardText>
+                                    <TextField className="netpyneField" floatingLabelText="File name" value={this.state.scriptName} onChange={(event) => this.setState({ scriptName: event.target.value })} />
+                                </CardText>
+                            </div>}
                         </Card>
                     </Tab>
                 </Tabs>

--- a/components/settings/Settings.js
+++ b/components/settings/Settings.js
@@ -38,21 +38,11 @@ const SettingsDialog = React.createClass({
     },
 
     componentWillReceiveProps(nextProps) {
-        // switch (nextProps.tab) {
-        //TODO: we need to define the rules here
         if (this.props.open != nextProps.open) {
             this.setState({
                 open: true
             });
         }
-    },
-
-    onChangeTab(value) {
-        this.setState({ currentTab: value });
-    },
-    
-    onChange(event, index, value) {
-        this.setState({exportFormat: value})
     },
 
     processError(parsedResponse) {
@@ -154,7 +144,7 @@ const SettingsDialog = React.createClass({
                 var children = <Tabs
                     style={{ paddingTop: 10 }}
                     value={this.state.currentTab}
-                    onChange={this.onChangeTab}
+                    onChange={(value) => this.setState({ currentTab: value })}
                     tabTemplateStyle={{ float: 'left', height: '100%' }}
                 >
                     <Tab value="import" label={'Import'}>
@@ -192,26 +182,22 @@ const SettingsDialog = React.createClass({
                         <Card style={{ padding: 10, float: 'left', width: '100%' }}>
                             <SelectField
                                 style={{marginLeft: 20}}
-                                floatingLabelText="format"
+                                floatingLabelText="Format"
                                 value={this.state.exportFormat}
-                                onChange={this.onChange}
+                                onChange={(event, index, value) => this.setState({exportFormat: value})}
                             >
                                 <MenuItem value={"json"} primaryText="JSON" />
                                 <MenuItem value={"netpyne script"} primaryText="NetPyNE script" />
                             </SelectField>
+                            <div style={{marginLeft: 20, float: 'left', color: 'rgba(0, 0, 0, 0.6)', marginBottom: 10}}>
                             {this.state.exportFormat=='json'?
-                                <CardHeader
-                                    title="Click on export to download the model as a json fle."
-                                    subtitle="File will be stored in the path specified in Configuration > Save Configuration > File Name."
-                                />:<div>
-                                <CardHeader
-                                    title="Save your work as NetPyNE script."
-                                    subtitle="The file will be saved in the current working directory (where you initialized NetPyNE-UI)"
-                                />
-                                <CardText>
+                                <span style={{marginTop: 20, float: 'left'}}>* File will be stored in the path specified in Configuration > Save Configuration > File Name.</span>
+                                :
+                                <div>
                                     <TextField className="netpyneField" floatingLabelText="File name" value={this.state.scriptName} onChange={(event) => this.setState({ scriptName: event.target.value })} />
-                                </CardText>
-                            </div>}
+                                    <span style={{marginTop: 20, float: 'left'}}>* File will be saved in the current working directory (where you initialized NetPyNE-UI)</span>
+                                </div>}
+                            </div>
                         </Card>
                     </Tab>
                 </Tabs>

--- a/components/settings/Settings.js
+++ b/components/settings/Settings.js
@@ -2,9 +2,8 @@ import React from 'react';
 import Dialog from 'material-ui/Dialog/Dialog';
 import FlatButton from 'material-ui/FlatButton/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
-import Card from 'material-ui/Card/Card';
-import CardText from 'material-ui/Card/CardText';
-import { Tabs, Tab } from 'material-ui/Tabs';
+import {Card, CardHeader, CardText} from 'material-ui/Card';
+import {Tabs, Tab } from 'material-ui/Tabs';
 import TextField from 'material-ui/TextField';
 import Checkbox from 'material-ui/Checkbox';
 import Utils from '../../Utils';
@@ -30,7 +29,8 @@ const SettingsDialog = React.createClass({
             explorerParameter: "",
             exploreOnlyDirs: false,
             errorMessage: undefined,
-            errorDetails: undefined
+            errorDetails: undefined,
+            scriptName: 'script_output'
         };
     },
 
@@ -63,12 +63,17 @@ const SettingsDialog = React.createClass({
             var action = 'netpyne_geppetto.importModel';
             var message = GEPPETTO.Resources.IMPORTING_MODEL;
         }
-        else {
+        else if (this.state.currentTab == "export") {
             var action = 'netpyne_geppetto.exportModel';
             var message = GEPPETTO.Resources.EXPORTING_MODEL;
         }
-        GEPPETTO.trigger(GEPPETTO.Events.Show_spinner, message);
+        else {
+            var action = 'netpyne_geppetto.generateScript';
+            var message = GEPPETTO.Resources.EXPORTING_MODEL;
+        }
 
+        GEPPETTO.trigger(GEPPETTO.Events.Show_spinner, message);
+        
         // Import/Export model python side
         this.closeDialog();
         Utils
@@ -134,7 +139,7 @@ const SettingsDialog = React.createClass({
                     cancelAction,
                     <RaisedButton
                         primary
-                        label={this.state.currentTab == "import" ? 'Import' : 'Export'}
+                        label={this.state.currentTab == "import" ? 'Import' : this.state.currentTab== 'Export'? 'Export': 'To script'}
                         onTouchTap={this.performAction}
                     />
                 ];
@@ -179,6 +184,18 @@ const SettingsDialog = React.createClass({
                         <div style={{ padding: 20 }}>
                             Click on export to download the model as a json fle. File will be stored in the path specified in Configuration > Save Configuration > File Name.
                         </div>
+                    </Tab>
+                    
+                    <Tab value="script" label={'To script'}>
+                        <Card style={{ padding: 10, float: 'left', width: '100%' }}>
+                            <CardHeader
+                                title="Save your work as NetPyNE script."
+                                subtitle="The file will be saved in the current working directory (where you initialized NetPyNE-UI)"
+                            />
+                            <CardText>
+                                <TextField className="netpyneField" floatingLabelText="File name" value={this.state.scriptName} onChange={(event) => this.setState({ scriptName: event.target.value })} />
+                            </CardText>
+                        </Card>
                     </Tab>
                 </Tabs>
             }


### PR DESCRIPTION
This requires: https://github.com/MetaCell/NetPyNE-UI/pull/64

Generate NetPyNE script from GUI user defined network.


### Test:

#### 1st test
- Open NetPyNE-UI and create some random populations, stimSource, change some settings or whatever.
- When you finished, open **settings** menu in the up right corner, 
- Click **To Script** tab
- Enter a name for the **.py** file
- Go to the folder where NetPyNE-UI was initialized
- Open the file that was recently created and take a look at it.
- Hopes it looks nice.

#### 2nd test
- Import a model into NetPyNE-UI (let's say tut3.py)
- Generate the script as described in **test 1**
- run in terminal `python /path_to_file/file_name.py` (this will run the code in normal NetPyNE form)

NOTE: sometimes plots are not shown. (if this is the case, you should add `import matplotlib.pyplot as plot` to the beginning of the script and `plot.show()` at the end. This happens depending on operating system.    