### PR TITLE
Call parent if value changed

### DIFF
--- a/components/definition/stimulationSources/NetPyNEStimulationSource.js
+++ b/components/definition/stimulationSources/NetPyNEStimulationSource.js
@@ -8,6 +8,7 @@ import NetPyNEField from '../../general/NetPyNEField';
 
 var PythonControlledCapability = require('../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
+var PythonControlledSelectField = PythonControlledCapability.createPythonControlledControl(SelectField);
 var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
 
 export default class NetPyNEStimulationSource extends React.Component {
@@ -16,25 +17,28 @@ export default class NetPyNEStimulationSource extends React.Component {
     super(props);
     this.state = {
       currentName: props.name,
-      sourceType: ''
     };
-    this.stimSourceTypeOptions = [
-      { type: 'IClamp' },
-      { type: 'VClamp' },
-        // TO BE READDED ONCE WE FIX DUR AND AMP TYPE
-      // { type: 'SEClamp' },
-      { type: 'NetStim' },
-      { type: 'AlphaSynapse' }
-    ];
+    
     this.handleStimSourceTypeChange = this.handleStimSourceTypeChange.bind(this);
   };
+  
+  componentDidMount() {
+    this.findCurrentSourceType()
+  }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.state.currentName != nextProps.name) {
-      this.setState({ currentName: nextProps.name, sourceType: null });
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.name != this.state.currentName) {
+      this.setState({ currentName: this.props.name})
+      this.findCurrentSourceType()
     };
   };
-
+  
+  findCurrentSourceType () {
+    Utils.sendPythonMessage("netParams.stimSourceParams['" + this.props.name + "']['type']").then((response) =>{
+      this.setState({ sourceType: response!=undefined? response : ''});
+    });
+  }
+  
   handleRenameChange = (event) => {
     var that = this;
     var storedValue = this.props.name;
@@ -53,28 +57,8 @@ export default class NetPyNEStimulationSource extends React.Component {
     this.updateTimer = setTimeout(updateMethod, 1000);
   };
 
-  componentDidMount() {
-    this.updateLayout();
-  };
-
-  componentDidUpdate(prevProps, prevState) {
-    if (this.state.currentName != prevState.currentName) {
-      this.updateLayout();
-    };
-  };
-
-  updateLayout() {
-    const getType = (value) => {
-      Utils
-        .sendPythonMessage("'" + value + "' in netParams.stimSourceParams['" + this.state.currentName + "']['type']")
-        .then((response) => { if (response == true) { this.setState({ sourceType: value }) } });
-    };
-    this.stimSourceTypeOptions.forEach((option) => { getType(option.type) });
-  };
-
-  handleStimSourceTypeChange(event, index, value) {
-    Utils.execPythonCommand("netpyne_geppetto.netParams.stimSourceParams['" + this.state.currentName + "']['type'] = '" + value + "'");
-    this.setState({ sourceType: value });
+  handleStimSourceTypeChange = (value) => {
+      this.setState({ sourceType: value });
   };
 
   render() {
@@ -82,21 +66,21 @@ export default class NetPyNEStimulationSource extends React.Component {
     if (this.state.sourceType == 'IClamp') {
       var variableContent = (
         <div>
+          <NetPyNEField id="netParams.stimSourceParams.amp">
+            <PythonControlledTextField
+              model={"netParams.stimSourceParams['" + this.props.name + "']['amp']"}
+            />
+          </NetPyNEField>
+        
           <NetPyNEField id="netParams.stimSourceParams.del">
             <PythonControlledTextField
               model={"netParams.stimSourceParams['" + this.props.name + "']['del']"}
             />
           </NetPyNEField>
-
+          
           <NetPyNEField id="netParams.stimSourceParams.dur">
             <PythonControlledTextField
               model={"netParams.stimSourceParams['" + this.props.name + "']['dur']"}
-            />
-          </NetPyNEField>
-
-          <NetPyNEField id="netParams.stimSourceParams.amp">
-            <PythonControlledTextField
-              model={"netParams.stimSourceParams['" + this.props.name + "']['amp']"}
             />
           </NetPyNEField>
 
@@ -212,42 +196,29 @@ export default class NetPyNEStimulationSource extends React.Component {
         </div>
       );
     } 
-    // TO BE READDED ONCE WE FIX DUR AND AMP TYPE
-    // else if (this.state.sourceType == 'SEClamp') {
-    //   var variableContent = (
-    //     <div>
-    //       <NetPyNEField id="netParams.stimSourceParams.rs">
-    //         <PythonControlledTextField
-    //           model={"netParams.stimSourceParams['" + this.props.name + "']['rs']"}
-    //         />
-    //       </NetPyNEField>
+    else if (this.state.sourceType == 'SEClamp') {
+      var variableContent = (
+        <div>
+          <NetPyNEField id="netParams.stimSourceParams.SECdur" className="listStyle">
+            <PythonControlledListComponent
+              model={"netParams.stimSourceParams['" + this.props.name + "']['dur']"}
+            />
+          </NetPyNEField>
+          
+          <NetPyNEField id="netParams.stimSourceParams.SECamp" className="listStyle">
+            <PythonControlledListComponent
+              model={"netParams.stimSourceParams['" + this.props.name + "']['amp']"}
+            />
+          </NetPyNEField>
 
-    //       <NetPyNEField id="netParams.stimSourceParams.dur" className="listStyle">
-    //         <PythonControlledListComponent
-    //           model={"netParams.stimSourceParams['" + this.props.name + "']['dur']"}
-    //         />
-    //       </NetPyNEField>
-
-    //       <NetPyNEField id="netParams.stimSourceParams.amp" className="listStyle">
-    //         <PythonControlledListComponent
-    //           model={"netParams.stimSourceParams['" + this.props.name + "']['amp']"}
-    //         />
-    //       </NetPyNEField>
-
-    //       <NetPyNEField id="netParams.stimSourceParams.i">
-    //         <PythonControlledTextField
-    //           model={"netParams.stimSourceParams['" + this.props.name + "']['i']"}
-    //         />
-    //       </NetPyNEField>
-
-    //       <NetPyNEField id="netParams.stimSourceParams.vc">
-    //         <PythonControlledTextField
-    //           model={"netParams.stimSourceParams['" + this.props.name + "']['vc']"}
-    //         />
-    //       </NetPyNEField>
-    //     </div>
-    //   )
-    // }
+          <NetPyNEField id="netParams.stimSourceParams.SECrs">
+            <PythonControlledTextField
+              model={"netParams.stimSourceParams['" + this.props.name + "']['rs']"}
+            />
+          </NetPyNEField>
+        </div>
+      )
+    }
     else {
       var variableContent = <div />
     };
@@ -262,21 +233,13 @@ export default class NetPyNEStimulationSource extends React.Component {
             className={"netpyneField"}
             id={"sourceName"}
           />
-          <br />
-
-          <NetPyNEField id="netParams.stimSourceParams.type" className={"netpyneFieldNoWidth"} noStyle>
-            <SelectField
-              floatingLabelText="stimulation type"
-              value={this.state.sourceType}
-              onChange={this.handleStimSourceTypeChange}
-            >
-              {(this.stimSourceTypeOptions != undefined) ?
-                this.stimSourceTypeOptions.map(function (stimSourceTypeOption) {
-                  return (<MenuItem key={stimSourceTypeOption.type} value={stimSourceTypeOption.type} primaryText={stimSourceTypeOption.type} />)
-                }) : null
-              }
-            </SelectField>
+          
+          <NetPyNEField id="netParams.stimSourceParams.type" >
+            <PythonControlledSelectField 
+              model={"netParams.stimSourceParams['" + this.state.currentName + "']['type']"} 
+              letParentKnowValueChanged={this.handleStimSourceTypeChange}/>
           </NetPyNEField>
+          <br />
         </div>
         {variableContent}
       </div>


### PR DESCRIPTION
this requires: 
- https://github.com/openworm/org.geppetto.frontend/pull/820
- https://github.com/Neurosim-lab/netpyne/pull/344

**PythonControlledControl** works wonderfully when we don't need to know the value of the field. But when we do (like in some **SelectFields** like **type** in **stimSourceParams.type**) we have decided not to use a **PythonControlledControl** and we prefer to go with a hard coding approach that requires to call `Utils.sendPyhtonMessage` and `Utils.excelPythonCommand`.

Here we are dropping all that and modifying ** PythonControlledControl** to let us know when the value in **SelectField** has changed. That gives us time to chose the proper components to render and to display the right fields.

There were some overlapped metadata in netpyne. that was also fixed.

We are also dropping the **triggerUpdate** Method for the **SelectField** wrappedComponent because it makes the GUI look a little bit choppy. 

### To Test:
- Go to Stimulation Sources
- Play around with different stimulation sources. The fields bellow **stimulation source** should be render according to the selected **stimulation source**. 
