### PR TITLE
change plot.include component

### DIFF
--- a/components/definition/plots/NetPyNEInclude.js
+++ b/components/definition/plots/NetPyNEInclude.js
@@ -1,20 +1,11 @@
 import React, { Component } from 'react';
 import Menu from 'material-ui/Menu';
-import Paper from 'material-ui/Paper';
 import Divider from 'material-ui/Divider';
 import MenuItem from 'material-ui/MenuItem';
 import TextField from 'material-ui/TextField';
-import FlatButton from 'material-ui/FlatButton';
 import Popover from 'material-ui/Popover/Popover';
-import SelectField from 'material-ui/SelectField';
-import DropDownMenu from 'material-ui/DropDownMenu';
-import ContentAdd from 'material-ui/svg-icons/content/add';
-import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
 import Utils from '../../../Utils';
 import NetPyNEField from '../../general/NetPyNEField';
-
-var PythonControlledCapability = require('../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
-
 
 export default class NetPyNEInclude extends Component {
  

--- a/components/definition/plots/NetPyNEInclude.js
+++ b/components/definition/plots/NetPyNEInclude.js
@@ -1,0 +1,367 @@
+import React, { Component } from 'react';
+import Menu from 'material-ui/Menu';
+import Paper from 'material-ui/Paper';
+import Divider from 'material-ui/Divider';
+import MenuItem from 'material-ui/MenuItem';
+import TextField from 'material-ui/TextField';
+import FlatButton from 'material-ui/FlatButton';
+import Popover from 'material-ui/Popover/Popover';
+import SelectField from 'material-ui/SelectField';
+import DropDownMenu from 'material-ui/DropDownMenu';
+import ContentAdd from 'material-ui/svg-icons/content/add';
+import ArrowDropRight from 'material-ui/svg-icons/navigation-arrow-drop-right';
+import Utils from '../../../Utils';
+import NetPyNEField from '../../general/NetPyNEField';
+
+var PythonControlledCapability = require('../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
+
+
+export default class NetPyNEInclude extends Component {
+ 
+  constructor(props) {
+    super(props);
+    this.state = {
+      include: this.getDataTemplate(),
+      mainPopoverOpen: false,
+      label: ''
+    };
+  };
+ 
+  componentDidMount() {
+    this.collectInfo();
+    // this.updateLayout();
+  };
+ 
+  XOR = (a, b) => {
+    return ( a || b ) && !( a && b );
+  }
+  
+  getDataTemplate = () => {
+    return {
+      gids: [],
+      groups: [],
+      popids: {},
+      exclusive: false 
+    }
+  }
+  checkEqual = (a, b) => {
+    // compare if 2 shallow dicts are equal (no DOM, no 2nd lvl, no functions)
+    var aProps = Object.getOwnPropertyNames(a);
+    var bProps = Object.getOwnPropertyNames(b);
+    if (aProps.length != bProps.length) {
+        return false;
+    }
+    for (var i = 0; i < aProps.length; i++) {
+        var propName = aProps[i];
+        if (a[propName] !== b[propName]) {
+            return false;
+        }
+    }
+    return true;
+  }
+  
+  whoIsIncluded = (include, data) => {
+    var pops = 0
+    var cells = 0
+    var answer = ""
+    if (include.exclusive) {
+      return include.exclusive + ' -- ' + data.gids + ' cells -- all NetStims'
+    }
+    else if (include.groups.indexOf('allCells')>-1) {
+      if (include.groups.indexOf('allNetStims')==-1) {
+        return 'allCells -- ' + data.gids + ' cells' 
+      }
+      else {
+        return 'all'+ ' -- ' + data.gids + ' cells -- all NetStims'
+      }
+    }
+    else {
+      include.groups.forEach(group => {
+        if (group!='allNetStims') {
+          pops += 1
+          cells += data[group]
+        }
+      })
+      cells += include.gids.length
+      Object.keys(include.popids).forEach(key => {
+        if (include.popids[key].length>0) {
+          cells += include.popids[key].length
+          pops +=1
+        }
+      })
+    }
+    if (pops>0) {
+      answer += pops + " pops -- "
+    }
+    answer += cells + " cells "
+    if (include.groups.indexOf('allNetStims')>-1) {
+      answer += " -- all netStims"
+    }
+    return answer
+  }
+  
+  sendToPython = () => {
+    var data = []
+    if (this.state.include.exclusive) {
+      data.push(this.state.include.exclusive)
+    }
+    else {
+      this.state.include.groups.forEach(group => data.push(group))
+      this.state.include.gids.forEach(gid => data.push(gid))
+      Object.keys(this.state.include.popids).forEach(key => data.push([key, this.state.include.popids[key]]))
+    }
+    Utils
+      .execPythonCommand("netpyne_geppetto." + this.props.model + " = " + JSON.stringify(data))
+  }
+  
+  convertFromPython(data) {
+    var out = this.getDataTemplate()
+    data.forEach((element) => {
+      switch(element.constructor.name) {
+          case 'Number':
+            out['gids'].push(element)
+            break;
+          case 'String':
+            element!='all'?out['groups'].push(element):out.exclusive='all'
+            break;
+          case 'Array':
+            if (element[1].constructor.name=='Number') {
+              out['popids'][element[0]] = [element[1]]
+            }
+            else {
+            	out['popids'][element[0]] = element[1]
+            }
+            break;
+          default:
+            break
+        }
+    });
+    return out
+  }
+  collectInfo = () =>{
+    Utils
+      .sendPythonMessage("netpyne_geppetto.getGIDs", [])
+      .then((response) => {
+        if (response) {
+          Utils
+            .sendPythonMessage(this.props.model)
+            .then((response2) => {
+              if (response2) {
+                var included = this.convertFromPython(response2)
+                var clone = Object.assign({}, response)
+                Object.keys(clone).forEach((key) => clone[key]=false)
+                this.setState({
+                  data: response,
+                  include: included,
+                  secondPopoverOpen: clone,
+                  label: this.whoIsIncluded(included, response)
+                })
+              }
+          })
+        }
+    })
+  }
+    
+  handleMainPopoverOpen = (open, preventDefault=false, target=false) => {
+    // This prevents ghost click -> 
+    if (preventDefault) {
+      preventDefault
+    }
+    // close all secondary popovers
+    var clone = Object.assign({}, this.state.secondPopoverOpen)
+    Object.keys(clone).forEach((key) => {clone[key] = false})
+    
+    if (this.XOR(open, this.state.mainPopoverOpen)) {
+      this.setState({
+        mainPopoverOpen: open, 
+        secondPopoverOpen: clone, 
+        anchorEl: target?target:this.state.anchorEl})
+    }
+    if (!open) {
+      this.sendToPython()
+      this.setState({label: this.whoIsIncluded(this.state.include, this.state.data)})
+    }
+  }
+  
+  handleSecondPopoverOpen = (name, open, preventDefault=false, target=false) => {
+    // This prevents ghost click -> 
+    if (preventDefault) {
+      preventDefault;
+    }
+    var clone = Object.assign({}, this.state.secondPopoverOpen)
+    Object.keys(clone).forEach((key) => {clone[key] = (key==name)?open:false})
+    
+    if (!this.checkEqual(clone, this.state.secondPopoverOpen)) {
+      this.setState({
+        secondPopoverOpen: clone,
+        anchorEl2: target?target:this.state.anchorEl,
+      });
+    }
+    else{
+    }
+  };
+  
+  closeSecondPopover = () => {
+    var clone = Object.assign({}, this.state.secondPopoverOpen)
+    Object.keys(clone).forEach((key) => {clone[key] = false})
+    if (!this.checkEqual(clone, this.state.secondPopoverOpen)) {
+      this.setState({
+        secondPopoverOpen: clone,
+      });
+    }
+    this.setState
+  }
+  
+  defaultMenues = () => {
+    // [all, allCells,  allNetStims]
+    var mainMenues = this.props.defaultOptions.map(name => {
+      return <MenuItem  
+        key={name}
+        value={name} 
+        primaryText={name}
+        insetChildren={true}
+        onClick={(e)=>this.handleItemClick(name, name=='all'?'exclusive':'groups')}
+        checked={this.state.include.exclusive==name||this.state.include.groups.indexOf(name)>-1?true:false}
+        onMouseEnter={(e) => this.closeSecondPopover()}
+      />
+    })
+    return <Menu>
+      {mainMenues}
+    </Menu>
+  }
+  
+  variableMenues = (name, size) => {
+    // size: how many sub-menuItems does the menuItem has
+    var menuItems = Array.from(Array(size).keys()).map(index => {
+      return <MenuItem 
+        key={name+index} 
+        value={index}
+        insetChildren={true}
+        primaryText={"cell "+index}
+        onClick={e => this.handleSubItemClick(name=='gids'?'gids':'popids', name, index)}
+        checked={this.subMenuItemChecked(name=='gids'?'gids':'popids', name, index)}
+      />
+    })
+    return <div key={name+"div"}>
+      <MenuItem 
+        key={name} 
+        value={name}
+        primaryText={name}
+        insetChildren={true}
+        checked={name!='gids'?this.state.include['groups'].indexOf(name)>-1?true:false:false}
+        onClick={name!='gids'?(e) => this.handleItemClick(name, 'groups'):(e)=>{}}
+        onMouseEnter={(e) => this.handleSecondPopoverOpen(name, true, e.preventDefault(), e.currentTarget)}
+      />
+      <Popover
+        style={{height: size<6?48*size:240, width:170}}
+        key={name+"Popover"}
+        useLayerForClickAway={false}
+        open={this.state.secondPopoverOpen?this.state.secondPopoverOpen[name]:false}
+        anchorEl={this.state.anchorEl2}
+        anchorOrigin={{"horizontal":"right", "vertical":"top"}}
+        targetOrigin={{"horizontal":"left", "vertical":"top"}}
+        >
+        {menuItems}
+      </Popover>
+    </div>
+  }
+  
+  handleItemClick = (name, group) => {
+    var clone = this.getDataTemplate()
+    if (name=='all'){ // remove everything else, when 'all' is selected
+      clone.exclusive = 'all'
+    }
+    else if (name=='allCells') {
+      clone['groups'] = ['allCells']
+      if (this.state.include['groups'].indexOf('allNetStims')>-1) {
+        clone['groups'].push('allNetStims')
+      }
+    }
+    else {
+      var clone = Object.assign({}, this.state.include)
+      clone[group].indexOf(name)==-1?clone[group].push(name):clone[group].splice( clone[group].indexOf(name), 1 );
+      clone['exclusive'] = false
+      if (name in clone['popids']) { //when selecting a whole pop, remove individual selections
+        delete clone['popids'][name]
+      }
+      if (this.state.include['groups'].indexOf('allCells')>-1 && name!='allNetStims') { //remove 'allCells' if selecting pops or individuals
+        clone['groups'].splice( clone['groups'].indexOf('allCells'), 1 );
+      } 
+    }
+    this.setState({include: clone})
+  }
+  
+  handleSubItemClick = (group, name, item) => {
+    var clone = Object.assign({}, this.state.include)
+    if (group=='gids') {
+      clone[group].indexOf(item)==-1?clone[group].push(item):clone[group].splice( clone[group].indexOf(item), 1 );
+    }
+    else if (group=='popids') {
+      if (name in clone[group]) {
+        clone[group][name].indexOf(item)==-1?clone[group][name].push(item):clone[group][name].splice( clone[group][name].indexOf(item), 1 );
+      }
+      else {
+        clone[group][name] = [item]
+      }
+      if (clone['groups'].indexOf(name)>-1) { // when selecting individuals, remove population selection
+        clone['groups'].splice( clone['groups'].indexOf(name), 1 )
+      }
+    }
+    else {
+    }
+    clone['exclusive'] = false
+    if (clone['groups'].indexOf('allCells')>-1 && name!='allNetStims') {
+      clone['groups'].splice( clone['groups'].indexOf('allCells'), 1 );
+    }
+    this.setState({include: clone})
+  }
+  
+  subMenuItemChecked = (group, name, index) => {
+    if (group=='gids') {
+      return this.state.include[group].indexOf(index)>-1?true:false
+    }
+    else if (group=='popids'){
+      if (name in this.state.include[group]) {
+        return this.state.include[group][name].indexOf(index)>-1?true:false
+      }
+      else {
+        return false
+      }
+    }
+  }
+  
+  otherMenues = () => {
+    var menuItems = []
+    for (var key in this.state.data) {
+      if (key!='gids'){
+        menuItems.push(this.variableMenues(key, this.state.data[key]))
+      }
+    }
+    return menuItems
+  }
+  
+  render() {
+    return  <div>
+      <NetPyNEField id={this.props.id}>
+        <TextField
+          floatingLabelText="Include in the plot"
+          value={this.state.label}
+          onClick={(e)=>this.handleMainPopoverOpen(true, e.preventDefault(), e.currentTarget)} 
+        />
+      </NetPyNEField >
+      <Popover 
+        open={this.state.mainPopoverOpen}
+        anchorEl={this.state.anchorEl}
+        onRequestClose={(e)=>this.handleMainPopoverOpen(false)}
+        anchorOrigin={{"horizontal":"left","vertical":"bottom"}}
+        targetOrigin={{"horizontal":"left","vertical":"top"}}
+      >
+        {this.defaultMenues()}
+        <Divider/>
+        {this.variableMenues('gids', this.state.data?this.state.data.gids:0, true)}
+        <Divider/>
+        {this.otherMenues()}
+      </Popover>
+    </div>
+  };
+};

--- a/components/definition/plots/plotTypes/Plot2Dnet.js
+++ b/components/definition/plots/plotTypes/Plot2Dnet.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import Checkbox from 'material-ui/Checkbox';
 import SelectField from 'material-ui/SelectField';
-import ListComponent from '../../../general/List';
+import NetPyNEInclude from '../NetPyNEInclude';
 import NetPyNEField from '../../../general/NetPyNEField';
 
 var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledCheckbox = PythonControlledCapability.createPythonControlledControl(Checkbox);
 var PythonControlledSelectField = PythonControlledCapability.createPythonControlledControl(SelectField);
-var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
 
 export default class Plot2Dnet extends React.Component {
 
@@ -20,9 +19,12 @@ export default class Plot2Dnet extends React.Component {
   render() {
     var tag = "simConfig.analysis['plot2Dnet']"
     return <div>
-      <NetPyNEField id="simConfig.analysis.plot2Dnet.include" className="listStyle" >
-        <PythonControlledListComponent model={tag+"['include']"} />
-      </NetPyNEField>
+      <NetPyNEInclude
+        id={"simConfig.analysis.plot2Dnet.include"}
+        model={tag+"['include']"} 
+        defaultOptions={['all', 'allCells', 'allNetStims']}
+        initialValue={'all'}
+      />
       
       <NetPyNEField id="simConfig.analysis.plot2Dnet.view" className="listStyle" >
         <PythonControlledSelectField model={tag+"['view']"} />

--- a/components/definition/plots/plotTypes/PlotConn.js
+++ b/components/definition/plots/plotTypes/PlotConn.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
 import SelectField from 'material-ui/SelectField';
-import ListComponent from '../../../general/List';
+import NetPyNEInclude from '../NetPyNEInclude';
 import NetPyNEField from '../../../general/NetPyNEField';
 
 var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledSelectField = PythonControlledCapability.createPythonControlledControl(SelectField);
-var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
 
 export default class plotConn extends React.Component {
 
@@ -18,9 +17,12 @@ export default class plotConn extends React.Component {
   render() {
     var tag = "simConfig.analysis['plotConn']"
     return <div>
-        <NetPyNEField id="simConfig.analysis.plotConn.include" className="listStyle" >
-          <PythonControlledListComponent model={tag + "['include']"} />
-        </NetPyNEField>
+        <NetPyNEInclude
+          id={"simConfig.analysis.plotConn.include"}
+          model={tag+"['include']"} 
+          defaultOptions={['all', 'allCells', 'allNetStims']}
+          initialValue={'all'}
+        />
         
         <NetPyNEField id="simConfig.analysis.plotConn.feature" className="listStyle" >
           <PythonControlledSelectField model={tag+"['feature']"} />

--- a/components/definition/plots/plotTypes/PlotGranger.js
+++ b/components/definition/plots/plotTypes/PlotGranger.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import TextField from 'material-ui/TextField';
 import TimeRange from '../TimeRange'
+import NetPyNEInclude from '../NetPyNEInclude';
 import ListComponent from '../../../general/List';
 import NetPyNEField from '../../../general/NetPyNEField';
 
@@ -20,13 +21,19 @@ export default class PlotGranger extends React.Component {
     var tags = "simConfig.analysis['granger']"
     var content = (
       <div>
-        <NetPyNEField id="simConfig.analysis.granger.cells1" className="listStyle" >
-          <PythonControlledListComponent model={tags + "['cells1']"} />
-        </NetPyNEField>
+        <NetPyNEInclude
+          id={"simConfig.analysis.granger.cells1"}
+          model={tags+ "['cells1']"} 
+          defaultOptions={['all', 'allCells', 'allNetStims']}
+          initialValue={'all'}
+        />
         
-        <NetPyNEField id="simConfig.analysis.granger.cells2" className="listStyle" >
-          <PythonControlledListComponent model={tags + "['cells2']"} />
-        </NetPyNEField>
+        <NetPyNEInclude
+          id={"simConfig.analysis.granger.cells2"}
+          model={tags+ "['cells2']"} 
+          defaultOptions={['all', 'allCells', 'allNetStims']}
+          initialValue={'all'}
+        />
         
         <NetPyNEField id="simConfig.analysis.granger.spks1" className="listStyle" >
           <PythonControlledListComponent model={tags + "['spks1']"} />

--- a/components/definition/plots/plotTypes/PlotRaster.js
+++ b/components/definition/plots/plotTypes/PlotRaster.js
@@ -3,14 +3,13 @@ import Checkbox from 'material-ui/Checkbox';
 import TextField from 'material-ui/TextField';
 import SelectField from 'material-ui/SelectField';
 import TimeRange from '../TimeRange'
-import ListComponent from '../../../general/List';
+import NetPyNEInclude from '../NetPyNEInclude';
 import NetPyNEField from '../../../general/NetPyNEField';
 
 var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledCheckbox = PythonControlledCapability.createPythonControlledControl(Checkbox);
 var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
 var PythonControlledSelectField = PythonControlledCapability.createPythonControlledControl(SelectField);
-var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
 
 export default class PlotRaster extends React.Component {
 
@@ -29,9 +28,12 @@ export default class PlotRaster extends React.Component {
   render() {
     var tag = "simConfig.analysis['plotRaster']"
     return <div>
-      <NetPyNEField id="simConfig.analysis.plotRaster.include" className="listStyle" >
-        <PythonControlledListComponent model={tag + "['include']"} />
-      </NetPyNEField>
+      <NetPyNEInclude
+        id={"simConfig.analysis.plotRaster.include"}
+        model={tag+"['include']"} 
+        defaultOptions={['all', 'allCells', 'allNetStims']}
+        initialValue={'all'}
+      />
       
       <NetPyNEField id="simConfig.analysis.plotRaster.timeRange" >
         <TimeRange model={tag + "['timeRange']"} />

--- a/components/definition/plots/plotTypes/PlotRatePSD.js
+++ b/components/definition/plots/plotTypes/PlotRatePSD.js
@@ -2,13 +2,12 @@ import React, { Component } from 'react';
 import Checkbox from 'material-ui/Checkbox';
 import TextField from 'material-ui/TextField';
 import TimeRange from '../TimeRange'
-import ListComponent from '../../../general/List';
+import NetPyNEInclude from '../NetPyNEInclude';
 import NetPyNEField from '../../../general/NetPyNEField';
 
 var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledCheckbox = PythonControlledCapability.createPythonControlledControl(Checkbox);
 var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
-var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
 
 export default class PlotRatePSD extends React.Component {
 
@@ -21,9 +20,12 @@ export default class PlotRatePSD extends React.Component {
   render() {
     var tag = "simConfig.analysis['plotRatePSD']"
     return <div>
-      <NetPyNEField id="simConfig.analysis.plotRatePSD.include" className="listStyle" >
-        <PythonControlledListComponent model={tag + "['include']"} />
-      </NetPyNEField>
+      <NetPyNEInclude
+        id={"simConfig.analysis.plotRatePSD.include"}
+        model={tag+"['include']"} 
+        defaultOptions={['all', 'allCells', 'allNetStims']}
+        initialValue={'all'}
+      />
       
       <NetPyNEField id="simConfig.analysis.plotRatePSD.timeRange" >
         <TimeRange model={tag + "['timeRange']"} />

--- a/components/definition/plots/plotTypes/PlotShape.js
+++ b/components/definition/plots/plotTypes/PlotShape.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import Checkbox from 'material-ui/Checkbox';
 import TextField from 'material-ui/TextField';
 import SelectField from 'material-ui/SelectField';
+import NetPyNEInclude from '../NetPyNEInclude';
 import ListComponent from '../../../general/List';
 import NetPyNEField from '../../../general/NetPyNEField';
 
@@ -22,14 +23,20 @@ export default class PlotShape extends React.Component {
   render() {
     var tag = "simConfig.analysis['plotShape']"
     return <div>
-      <NetPyNEField id="simConfig.analysis.plotShape.includePre" className="listStyle" >
-        <PythonControlledListComponent model={tag + "['includePre']"} />
-      </NetPyNEField>
-
-      <NetPyNEField id="simConfig.analysis.plotShape.includePost" className="listStyle" >
-        <PythonControlledListComponent model={tag + "['includePost']"} />
-      </NetPyNEField>
-
+      <NetPyNEInclude
+        id={"simConfig.analysis.plotShape.includePre"}
+        model={tag+"['includePre']"} 
+        defaultOptions={['all', 'allCells', 'allNetStims']}
+        initialValue={'all'}
+      />
+      
+      <NetPyNEInclude
+        id={"simConfig.analysis.plotShape.includePost"}
+        model={tag+"['includePost']"} 
+        defaultOptions={['all', 'allCells', 'allNetStims']}
+        initialValue={'all'}
+      />
+      
       <NetPyNEField id="simConfig.analysis.plotShape.synStyle" >
         <PythonControlledTextField model={tag + "['synStyle']"} />
       </NetPyNEField>

--- a/components/definition/plots/plotTypes/PlotSpikeHist.js
+++ b/components/definition/plots/plotTypes/PlotSpikeHist.js
@@ -3,14 +3,13 @@ import Checkbox from 'material-ui/Checkbox';
 import TextField from 'material-ui/TextField';
 import SelectField from 'material-ui/SelectField';
 import TimeRange from '../TimeRange'
-import ListComponent from '../../../general/List';
+import NetPyNEInclude from '../NetPyNEInclude';
 import NetPyNEField from '../../../general/NetPyNEField';
 
 var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledCheckbox = PythonControlledCapability.createPythonControlledControl(Checkbox);
 var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
 var PythonControlledSelectField = PythonControlledCapability.createPythonControlledControl(SelectField);
-var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
 
 export default class PlotSpikeHist extends React.Component {
 
@@ -23,9 +22,12 @@ export default class PlotSpikeHist extends React.Component {
   render() {
     var tag = "simConfig.analysis['plotSpikeHist']"
     return <div >
-      <NetPyNEField id="simConfig.analysis.plotSpikeHist.include" className="listStyle" >
-        <PythonControlledListComponent model={tag + "['include']"} />
-      </NetPyNEField>
+      <NetPyNEInclude
+        id={"simConfig.analysis.plotSpikeHist.include"}
+        model={tag+"['include']"} 
+        defaultOptions={['all', 'allCells', 'allNetStims']}
+        initialValue={'all'}
+      />
       
       <NetPyNEField id="simConfig.analysis.plotSpikeHist.timeRange" >
         <TimeRange model={tag + "['timeRange']"} />

--- a/components/definition/plots/plotTypes/PlotSpikeStats.js
+++ b/components/definition/plots/plotTypes/PlotSpikeStats.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import TextField from 'material-ui/TextField';
 import SelectField from 'material-ui/SelectField';
 import TimeRange from '../TimeRange'
+import NetPyNEInclude from '../NetPyNEInclude';
 import ListComponent from '../../../general/List';
 import NetPyNEField from '../../../general/NetPyNEField';
 
@@ -21,9 +22,12 @@ export default class PlotSpikeStats extends React.Component {
   render() {
     var tag = "simConfig.analysis['plotSpikeStats']"
     return <div>
-      <NetPyNEField id="simConfig.analysis.plotSpikeStats.include" className="listStyle" >
-        <PythonControlledListComponent model={tag + "['include']"} />
-      </NetPyNEField>
+      <NetPyNEInclude
+        id={"simConfig.analysis.plotSpikeStats.include"}
+        model={tag+"['include']"} 
+        defaultOptions={['all', 'allCells', 'allNetStims']}
+        initialValue={'all'}
+      />
       
       <NetPyNEField id="simConfig.analysis.plotSpikeStats.timeRange" >
         <TimeRange model={tag + "['timeRange']"} />

--- a/components/definition/plots/plotTypes/PlotTraces.js
+++ b/components/definition/plots/plotTypes/PlotTraces.js
@@ -3,14 +3,13 @@ import Checkbox from 'material-ui/Checkbox';
 import TextField from 'material-ui/TextField';
 import SelectField from 'material-ui/SelectField';
 import TimeRange from '../TimeRange'
-import ListComponent from '../../../general/List';
+import NetPyNEInclude from '../NetPyNEInclude';
 import NetPyNEField from '../../../general/NetPyNEField';
 
 var PythonControlledCapability = require('../../../../../../js/communication/geppettoJupyter/PythonControlledCapability');
 var PythonControlledCheckbox = PythonControlledCapability.createPythonControlledControl(Checkbox);
 var PythonControlledTextField = PythonControlledCapability.createPythonControlledControl(TextField);
 var PythonControlledSelectField = PythonControlledCapability.createPythonControlledControl(SelectField);
-var PythonControlledListComponent = PythonControlledCapability.createPythonControlledControl(ListComponent);
 
 export default class PlotTraces extends React.Component {
 
@@ -23,10 +22,13 @@ export default class PlotTraces extends React.Component {
   render() {
     var tag = "simConfig.analysis['plotTraces']"
     return <div>
-      <NetPyNEField id="simConfig.analysis.plotTraces.include" className="listStyle" >
-        <PythonControlledListComponent model={tag + "['include']"} />
-      </NetPyNEField>
-
+      <NetPyNEInclude
+        id={"simConfig.analysis.plotTraces.include"}
+        model={tag+"['include']"} 
+        defaultOptions={['all', 'allCells', 'allNetStims']}
+        initialValue={'all'}
+      />
+      
       <NetPyNEField id="simConfig.analysis.plotTraces.timeRange" >
         <TimeRange model={tag + "['timeRange']"} />
       </NetPyNEField>

--- a/components/general/NetPyNEField.js
+++ b/components/general/NetPyNEField.js
@@ -86,7 +86,7 @@ export default class NetPyNEField extends Component {
         const childWithProp = React.Children.map(this.props.children, (child) => {
             var extraProps = {}
             
-            if (child.type.name != "SelectField" && child.type.name != 'PythonControlledControlWithPythonDataFetch') {
+            if (child.type.name != "SelectField" && child.type.name!="TextField" && child.type.name != 'PythonControlledControlWithPythonDataFetch') {
                 extraProps['validate'] = this.setErrorMessage;
                 extraProps['prePythonSyncProcessing'] = this.prePythonSyncProcessing;
 


### PR DESCRIPTION
### This requires:
- sync with netpyne/metadata
- https://github.com/MetaCell/NetPyNE-UI/pull/70

### About simConfig.analysis.plot.include
all plots have a field **include** (of type list) to select which cells to include in the plot. The field accepts the following data types:
- string.       -->     'all'  |  'allCells' | "my_population"  |  "another_population"
- number     -->.     1,2, 445.     (cells global id's)
- tuple         -->.     ( "popLabel",  [1, 2 45, 234] )

### Current behavior
Right now we have decided to use a ListComponent (accepting only global id's).


### Propose behavior 
This PR uses menuItems to guide the user through the different options:
![animation](https://user-images.githubusercontent.com/32278395/44555690-cfa5dd00-a70c-11e8-8823-4879fd3768cf.gif)
 
### Test
- Add some populations and assign them a size through **numCells** field (other options are not allowed because sizes are computed after instantiation)
- add a new plot and fill it up by clicking in the different menuItems
- type `simConfig.analyses["plotRaster"]["include"]` in the notebook to check the field.
- Other option would be to load tut3.py and then instantiate and run to check the plots contain only those cells defined in the **include** field.