### PR TITLE
Names collision

### DIFF
--- a/components/definition/cellRules/NetPyNECellRule.js
+++ b/components/definition/cellRules/NetPyNECellRule.js
@@ -25,12 +25,18 @@ export default class NetPyNECellRule extends React.Component {
     var that = this;
     var storedValue = this.props.name;
     var newValue = event.target.value;
+    var updateCondition = this.props.renameHandler(newValue);
     this.setState({ currentName: newValue });
-    this.triggerUpdate(function () {
-      // Rename the population in Python
-      Utils.renameKey('netParams.cellParams', storedValue, newValue, (response, newValue) => { that.renaming = false; });
-      that.renaming = true;
-    });
+    if(updateCondition) {
+      this.triggerUpdate(function () {
+        // Rename the population in Python
+        Utils.renameKey('netParams.cellParams', storedValue, newValue, (response, newValue) => { that.renaming = false; });
+        that.renaming = true;
+      });
+    } else {
+      console.log("Rename forbidden, "+newValue+" already used.");
+    }
+
 
   }
 

--- a/components/definition/cellRules/NetPyNECellRule.js
+++ b/components/definition/cellRules/NetPyNECellRule.js
@@ -33,11 +33,7 @@ export default class NetPyNECellRule extends React.Component {
         Utils.renameKey('netParams.cellParams', storedValue, newValue, (response, newValue) => { that.renaming = false; });
         that.renaming = true;
       });
-    } else {
-      console.log("Rename forbidden, "+newValue+" already used.");
     }
-
-
   }
 
   triggerUpdate(updateMethod) {

--- a/components/definition/cellRules/NetPyNECellRules.js
+++ b/components/definition/cellRules/NetPyNECellRules.js
@@ -64,10 +64,10 @@ export default class NetPyNECellRules extends React.Component {
 
     // Get New Available ID
     var cellRuleId = Utils.getAvailableKey(model, key);
-
+    var newCellRule = Object.assign({name: cellRuleId}, value);
     // Create Cell Rule Client side
     Utils.execPythonCommand('netpyne_geppetto.netParams.cellParams["' + cellRuleId + '"] = ' + JSON.stringify(value));
-
+    model[cellRuleId] = newCellRule;
     // Update state
     this.setState({
       value: model,
@@ -88,13 +88,13 @@ export default class NetPyNECellRules extends React.Component {
 
     // Get New Available ID
     var sectionId = Utils.getAvailableKey(model[selectedCellRule]['secs'], key);
-
+    var newSection = Object.assign({name: sectionId}, value);
     if (model[selectedCellRule]['secs'] == undefined) {
       model[selectedCellRule]['secs'] = {};
       Utils.execPythonCommand('netpyne_geppetto.netParams.cellParams["' + selectedCellRule + '"]["secs"] = {}');
     }
     Utils.execPythonCommand('netpyne_geppetto.netParams.cellParams["' + selectedCellRule + '"]["secs"]["' + sectionId + '"] = ' + JSON.stringify(value));
-
+    model[selectedCellRule]["secs"][sectionId] = newSection;
     // Update state
     this.setState({
       value: model,

--- a/components/definition/cellRules/sections/NetPyNESection.js
+++ b/components/definition/cellRules/sections/NetPyNESection.js
@@ -42,12 +42,17 @@ export default class NetPyNESection extends React.Component {
     var that = this;
     var storedValue = this.props.name;
     var newValue = event.target.value;
+    var updateCondition = this.props.renameHandler(newValue);
     this.setState({ currentName: newValue });
-    this.triggerUpdate(function () {
-      // Rename the population in Python
-      Utils.renameKey("netParams.cellParams['" + that.props.cellRule + "']['secs']", storedValue, newValue, (response, newValue) => { });
-    });
 
+    if(updateCondition) {
+      this.triggerUpdate(function () {
+        // Rename the population in Python
+        Utils.renameKey("netParams.cellParams['" + that.props.cellRule + "']['secs']", storedValue, newValue, (response, newValue) => { });
+      });
+    } else {
+      console.log("Rename forbidden, "+newValue+" already used.");
+    }
   }
 
   triggerUpdate(updateMethod) {

--- a/components/definition/cellRules/sections/NetPyNESection.js
+++ b/components/definition/cellRules/sections/NetPyNESection.js
@@ -50,8 +50,6 @@ export default class NetPyNESection extends React.Component {
         // Rename the population in Python
         Utils.renameKey("netParams.cellParams['" + that.props.cellRule + "']['secs']", storedValue, newValue, (response, newValue) => { });
       });
-    } else {
-      console.log("Rename forbidden, "+newValue+" already used.");
     }
   }
 

--- a/components/definition/connectivity/NetPyNEConnectivityRule.js
+++ b/components/definition/connectivity/NetPyNEConnectivityRule.js
@@ -30,12 +30,19 @@ export default class NetPyNEConnectivityRule extends React.Component {
     var that = this;
     var storedValue = this.props.name;
     var newValue = event.target.value;
+    var updateCondition = this.props.renameHandler(newValue);
     this.setState({ currentName: newValue });
-    this.triggerUpdate(function () {
-      // Rename the population in Python
-      Utils.renameKey('netParams.connParams', storedValue, newValue, (response, newValue) => { that.renaming = false; });
-      that.renaming = true;
-    });
+
+    if(updateCondition) {
+      this.triggerUpdate(function () {
+        // Rename the population in Python
+        Utils.renameKey('netParams.connParams', storedValue, newValue, (response, newValue) => { that.renaming = false; });
+        that.renaming = true;
+      });
+    } else {
+      console.log("Rename forbidden, "+newValue+" already used.");
+    }
+
 
   }
 

--- a/components/definition/connectivity/NetPyNEConnectivityRule.js
+++ b/components/definition/connectivity/NetPyNEConnectivityRule.js
@@ -39,11 +39,7 @@ export default class NetPyNEConnectivityRule extends React.Component {
         Utils.renameKey('netParams.connParams', storedValue, newValue, (response, newValue) => { that.renaming = false; });
         that.renaming = true;
       });
-    } else {
-      console.log("Rename forbidden, "+newValue+" already used.");
     }
-
-
   }
 
   triggerUpdate(updateMethod) {

--- a/components/definition/connectivity/NetPyNEConnectivityRules.js
+++ b/components/definition/connectivity/NetPyNEConnectivityRules.js
@@ -15,6 +15,7 @@ export default class NetPyNEConnectivityRules extends React.Component {
     this.state = {
       drawerOpen: false,
       selectedConnectivityRule: undefined,
+      deletedConnectivityRule: undefined,
       page: "main"
     };
 
@@ -23,6 +24,8 @@ export default class NetPyNEConnectivityRules extends React.Component {
     this.selectConnectivityRule = this.selectConnectivityRule.bind(this);
     this.handleNewConnectivityRule = this.handleNewConnectivityRule.bind(this);
     this.deleteConnectivityRule = this.deleteConnectivityRule.bind(this);
+
+    this.handleRenameChildren = this.handleRenameChildren.bind(this);
   }
 
   handleToggle = () => this.setState({ drawerOpen: !this.state.drawerOpen });
@@ -91,7 +94,7 @@ export default class NetPyNEConnectivityRules extends React.Component {
     //we need to check if any of the three entities have been renamed and if that's the case change the state for the selection variable
     var newConnectivityRuleName = this.hasSelectedConnectivityRuleBeenRenamed(prevState, this.state);
     if (newConnectivityRuleName !== undefined) {
-      this.setState({ selectedConnectivityRule: newConnectivityRuleName });
+      this.setState({ selectedConnectivityRule: newConnectivityRuleName, deletedConnectivityRule: undefined });
     }
   }
 
@@ -102,7 +105,7 @@ export default class NetPyNEConnectivityRules extends React.Component {
     var pageChanged = this.state.page != nextState.page;
     var newModel = this.state.value == undefined;
     if (!newModel) {
-      newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
+      newItemCreated = ((Object.keys(this.state.value).length != Object.keys(nextState.value).length) && (this.state.deletedConnectivityRule !== undefined));
     }
     return newModel || newItemCreated || itemRenamed || selectionChanged || pageChanged;
   }
@@ -111,8 +114,19 @@ export default class NetPyNEConnectivityRules extends React.Component {
     Utils.sendPythonMessage('netpyne_geppetto.deleteParam', ["connParams['" + name + "']"]).then((response) =>{
       var model = this.state.value;
       delete model[name];
-      this.setState({value: model, selectedConnectivityRule: undefined});
+      this.setState({value: model, selectedConnectivityRule: undefined, deletedConnectivityRule: name});
     });
+  }
+
+  handleRenameChildren(childName) {
+    childName = childName.replace(/\s*$/,"");
+    var childrenList = Object.keys(this.state.value);
+    for(var i=0 ; childrenList.length > i ; i++) {
+      if(childName === childrenList[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   render() {
@@ -133,7 +147,7 @@ export default class NetPyNEConnectivityRules extends React.Component {
       }
       var selectedConnectivityRule = undefined;
       if ((this.state.selectedConnectivityRule !== undefined) && Object.keys(model).indexOf(this.state.selectedConnectivityRule)>-1) {
-        selectedConnectivityRule = <NetPyNEConnectivityRule name={this.state.selectedConnectivityRule} model={this.state.value[this.state.selectedConnectivityRule]} selectPage={this.selectPage} />;
+        selectedConnectivityRule = <NetPyNEConnectivityRule name={this.state.selectedConnectivityRule} model={this.state.value[this.state.selectedConnectivityRule]} selectPage={this.selectPage} renameHandler={this.handleRenameChildren} />;
       }
 
       content = (

--- a/components/definition/connectivity/NetPyNEConnectivityRules.js
+++ b/components/definition/connectivity/NetPyNEConnectivityRules.js
@@ -54,10 +54,10 @@ export default class NetPyNEConnectivityRules extends React.Component {
 
     // Get New Available ID
     var connectivityRuleId = Utils.getAvailableKey(model, key);
-
+    var newConnectivityRule = Object.assign({name: connectivityRuleId}, value);
     // Create Cell Rule Client side
     Utils.execPythonCommand('netpyne_geppetto.netParams.connParams["' + connectivityRuleId + '"] = ' + JSON.stringify(value));
-
+    model[connectivityRuleId] = newConnectivityRule;
     // Update state
     this.setState({
       value: model,

--- a/components/definition/populations/NetPyNEPopulation.js
+++ b/components/definition/populations/NetPyNEPopulation.js
@@ -91,8 +91,6 @@ export default class NetPyNEPopulation extends React.Component {
         Utils.renameKey('netParams.popParams', storedValue, newValue, (response, newValue) => { that.renaming = false });
         that.renaming = true;
       });
-    } else {
-      console.log("Rename forbidden, "+newValue+" already used.");
     }
   }
 

--- a/components/definition/populations/NetPyNEPopulation.js
+++ b/components/definition/populations/NetPyNEPopulation.js
@@ -83,13 +83,17 @@ export default class NetPyNEPopulation extends React.Component {
     var that = this;
     var storedValue = this.props.name;
     var newValue = event.target.value;
+    var updateCondition = this.props.renameHandler(newValue);
     this.setState({ currentName: newValue });
-    this.triggerUpdate(function () {
-      // Rename the population in Python
-      Utils.renameKey('netParams.popParams', storedValue, newValue, (response, newValue) => { that.renaming = false });
-      that.renaming = true;
-    });
-
+    if(updateCondition) {
+      this.triggerUpdate(function () {
+        // Rename the population in Python
+        Utils.renameKey('netParams.popParams', storedValue, newValue, (response, newValue) => { that.renaming = false });
+        that.renaming = true;
+      });
+    } else {
+      console.log("Rename forbidden, "+newValue+" already used.");
+    }
   }
 
   triggerUpdate(updateMethod) {

--- a/components/definition/stimulationSources/NetPyNEStimulationSource.js
+++ b/components/definition/stimulationSources/NetPyNEStimulationSource.js
@@ -38,11 +38,17 @@ export default class NetPyNEStimulationSource extends React.Component {
     var that = this;
     var storedValue = this.props.name;
     var newValue = event.target.value;
+    var updateCondition = this.props.renameHandler(newValue);
     this.setState({ currentName: newValue });
-    this.triggerUpdate(function () {
-      Utils.renameKey('netParams.stimSourceParams', storedValue, newValue, (response, newValue) => { that.renaming = false });
-      that.renaming = true;
-    });
+
+    if(updateCondition) {
+      this.triggerUpdate(function () {
+        Utils.renameKey('netParams.stimSourceParams', storedValue, newValue, (response, newValue) => { that.renaming = false });
+        that.renaming = true;
+      });
+    } else {
+      console.log("Rename forbidden, "+newValue+" already used.");
+    }
   };
 
   triggerUpdate(updateMethod) {

--- a/components/definition/stimulationSources/NetPyNEStimulationSource.js
+++ b/components/definition/stimulationSources/NetPyNEStimulationSource.js
@@ -46,8 +46,6 @@ export default class NetPyNEStimulationSource extends React.Component {
         Utils.renameKey('netParams.stimSourceParams', storedValue, newValue, (response, newValue) => { that.renaming = false });
         that.renaming = true;
       });
-    } else {
-      console.log("Rename forbidden, "+newValue+" already used.");
     }
   };
 

--- a/components/definition/stimulationSources/NetPyNEStimulationSources.js
+++ b/components/definition/stimulationSources/NetPyNEStimulationSources.js
@@ -33,7 +33,9 @@ export default class NetPyNEStimulationSources extends React.Component {
     var value = defaultStimulationSources[key];
     var model = this.state.value;
     var StimulationSourceId = Utils.getAvailableKey(model, key);
+    var newStimulationSource = Object.assign({name: StimulationSourceId}, value);
     Utils.execPythonCommand('netpyne_geppetto.netParams.stimSourceParams["' + StimulationSourceId + '"] = ' + JSON.stringify(value));
+    model[StimulationSourceId] = newStimulationSource;
     this.setState({
       value: model,
       selectedStimulationSource: StimulationSourceId

--- a/components/definition/stimulationSources/NetPyNEStimulationSources.js
+++ b/components/definition/stimulationSources/NetPyNEStimulationSources.js
@@ -12,11 +12,14 @@ export default class NetPyNEStimulationSources extends React.Component {
     super(props);
     this.state = {
       selectedStimulationSource: undefined,
+      deletedStimulationSource: undefined,
       page: "main"
     };
     this.selectStimulationSource = this.selectStimulationSource.bind(this);
     this.handleNewStimulationSource = this.handleNewStimulationSource.bind(this);
     this.deleteStimulationSource = this.deleteStimulationSource.bind(this);
+
+    this.handleRenameChildren = this.handleRenameChildren.bind(this);
   };
 
   /* Method that handles button click */
@@ -63,7 +66,7 @@ export default class NetPyNEStimulationSources extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     var newStimulationSourceName = this.hasSelectedStimulationSourceBeenRenamed(prevState, this.state);
     if (newStimulationSourceName !== undefined) {
-      this.setState({ selectedStimulationSource: newStimulationSourceName });
+      this.setState({ selectedStimulationSource: newStimulationSourceName, deletedStimulationSource: undefined });
     };
   };
 
@@ -74,7 +77,7 @@ export default class NetPyNEStimulationSources extends React.Component {
     var pageChanged = this.state.page != nextState.page;
     var newModel = this.state.value == undefined;
     if (this.state.value!=undefined) {
-      newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
+      newItemCreated = ((Object.keys(this.state.value).length != Object.keys(nextState.value).length) && (this.state.deletedStimulationSource !== undefined));
     };
     return newModel || newItemCreated || itemRenamed || selectionChanged || pageChanged;
   };
@@ -83,8 +86,19 @@ export default class NetPyNEStimulationSources extends React.Component {
     Utils.sendPythonMessage('netpyne_geppetto.deleteParam', ["stimSourceParams['" + name + "']"]).then((response) =>{
       var model = this.state.value;
       delete model[name];
-      this.setState({value: model, selectedStimulationSource: undefined});
+      this.setState({value: model, selectedStimulationSource: undefined, deletedStimulationSource: name});
     });
+  }
+
+  handleRenameChildren(childName) {
+    childName = childName.replace(/\s*$/,"");
+    var childrenList = Object.keys(this.state.value);
+    for(var i=0 ; childrenList.length > i ; i++) {
+      if(childName === childrenList[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   render() {
@@ -101,7 +115,7 @@ export default class NetPyNEStimulationSources extends React.Component {
     
     var selectedStimulationSource = undefined;
     if ((this.state.selectedStimulationSource !== undefined) && Object.keys(model).indexOf(this.state.selectedStimulationSource)>-1) {
-      selectedStimulationSource = <NetPyNEStimulationSource name={this.state.selectedStimulationSource} />;
+      selectedStimulationSource = <NetPyNEStimulationSource name={this.state.selectedStimulationSource} renameHandler={this.handleRenameChildren} />;
     };
     
     var content = (

--- a/components/definition/stimulationTargets/NetPyNEStimulationTarget.js
+++ b/components/definition/stimulationTargets/NetPyNEStimulationTarget.js
@@ -48,8 +48,6 @@ export default class NetPyNEStimulationTarget extends React.Component {
         Utils.renameKey('netParams.stimTargetParams', storedValue, newValue, (response, newValue) => { that.renaming=false;});
         that.renaming=true;
       });
-    } else {
-      console.log("Rename forbidden, "+newValue+" already used.");
     }
   };
 

--- a/components/definition/stimulationTargets/NetPyNEStimulationTarget.js
+++ b/components/definition/stimulationTargets/NetPyNEStimulationTarget.js
@@ -40,11 +40,17 @@ export default class NetPyNEStimulationTarget extends React.Component {
     var that = this;
     var storedValue = this.props.name;
     var newValue = event.target.value;
+    var updateCondition = this.props.renameHandler(newValue);
     this.setState({ currentName: newValue });
-    this.triggerUpdate(function () {
-      Utils.renameKey('netParams.stimTargetParams', storedValue, newValue, (response, newValue) => { that.renaming=false;});
-      that.renaming=true;
-    });
+
+    if(updateCondition) {
+      this.triggerUpdate(function () {
+        Utils.renameKey('netParams.stimTargetParams', storedValue, newValue, (response, newValue) => { that.renaming=false;});
+        that.renaming=true;
+      });
+    } else {
+      console.log("Rename forbidden, "+newValue+" already used.");
+    }
   };
 
   triggerUpdate(updateMethod) {

--- a/components/definition/stimulationTargets/NetPyNEStimulationTargets.js
+++ b/components/definition/stimulationTargets/NetPyNEStimulationTargets.js
@@ -35,7 +35,9 @@ export default class NetPyNEStimulationTargets extends React.Component {
     var value = defaultStimulationTargets[key];
     var model = this.state.value;
     var StimulationTargetId = Utils.getAvailableKey(model, key);
+    var newStimulationTarget = Object.assign({name: StimulationTargetId}, value);
     Utils.execPythonCommand('netpyne_geppetto.netParams.stimTargetParams["' + StimulationTargetId + '"] = ' + JSON.stringify(value));
+    model[StimulationTargetId] = newStimulationTarget;
     this.setState({
       value: model,
       selectedStimulationTarget: StimulationTargetId

--- a/components/definition/stimulationTargets/NetPyNEStimulationTargets.js
+++ b/components/definition/stimulationTargets/NetPyNEStimulationTargets.js
@@ -12,11 +12,14 @@ export default class NetPyNEStimulationTargets extends React.Component {
     super(props);
     this.state = {
       selectedStimulationTarget: undefined,
+      deletedStimulationTarget: undefined,
       page: "main"
     };
     this.selectStimulationTarget = this.selectStimulationTarget.bind(this);
     this.handleNewStimulationTarget = this.handleNewStimulationTarget.bind(this);
     this.deleteStimulationTarget = this.deleteStimulationTarget.bind(this);
+
+    this.handleRenameChildren = this.handleRenameChildren.bind(this);
   };
 
   /* Method that handles button click */
@@ -65,7 +68,7 @@ export default class NetPyNEStimulationTargets extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     var newStimulationTargetName = this.hasSelectedStimulationTargetBeenRenamed(prevState, this.state);
     if (newStimulationTargetName !== undefined) {
-      this.setState({ selectedStimulationTarget: newStimulationTargetName });
+      this.setState({ selectedStimulationTarget: newStimulationTargetName, deletedStimulationTarget: undefined });
     };
   };
 
@@ -76,7 +79,7 @@ export default class NetPyNEStimulationTargets extends React.Component {
     var pageChanged = this.state.page != nextState.page;
     var newModel = this.state.value == undefined;
     if (this.state.value!=undefined) {
-      newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
+      newItemCreated = ((Object.keys(this.state.value).length != Object.keys(nextState.value).length) && (this.state.deletedStimulationTarget !== undefined));
     };
     return newModel || newItemCreated || itemRenamed || selectionChanged || pageChanged;
   };
@@ -85,8 +88,19 @@ export default class NetPyNEStimulationTargets extends React.Component {
     Utils.sendPythonMessage('netpyne_geppetto.deleteParam', ["stimTargetParams['" + name + "']"]).then((response) =>{
       var model = this.state.value;
       delete model[name];
-      this.setState({value: model, selectedStimulationTarget: undefined});
+      this.setState({value: model, selectedStimulationTarget: undefined, deletedStimulationTarget: name});
     });
+  }
+
+  handleRenameChildren(childName) {
+    childName = childName.replace(/\s*$/,"");
+    var childrenList = Object.keys(this.state.value);
+    for(var i=0 ; childrenList.length > i ; i++) {
+      if(childName === childrenList[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   render() {
@@ -102,7 +116,7 @@ export default class NetPyNEStimulationTargets extends React.Component {
     };
     var selectedStimulationTarget = undefined;
     if ((this.state.selectedStimulationTarget !== undefined) && Object.keys(model).indexOf(this.state.selectedStimulationTarget)>-1) {
-      selectedStimulationTarget = <NetPyNEStimulationTarget name={this.state.selectedStimulationTarget}/>;
+      selectedStimulationTarget = <NetPyNEStimulationTarget name={this.state.selectedStimulationTarget} renameHandler={this.handleRenameChildren}/>;
     };
 
     var content = (

--- a/components/definition/synapses/NetPyNESynapse.js
+++ b/components/definition/synapses/NetPyNESynapse.js
@@ -32,13 +32,18 @@ export default class NetPyNESynapse extends React.Component {
     var that = this;
     var storedValue = this.props.name;
     var newValue = event.target.value;
+    var updateCondition = this.props.renameHandler(newValue);
     this.setState({ currentName: newValue });
-    this.triggerUpdate(function () {
-      // Rename the population in Python
-      Utils.renameKey('netParams.synMechParams', storedValue, newValue, (response, newValue) => { that.renaming=false;});
-      that.renaming=true;
-    });
 
+    if(updateCondition) {
+      this.triggerUpdate(function () {
+        // Rename the population in Python
+        Utils.renameKey('netParams.synMechParams', storedValue, newValue, (response, newValue) => { that.renaming=false;});
+        that.renaming=true;
+      });
+    } else {
+      console.log("Rename forbidden, "+newValue+" already used.");
+    }
   }
 
   triggerUpdate(updateMethod) {

--- a/components/definition/synapses/NetPyNESynapse.js
+++ b/components/definition/synapses/NetPyNESynapse.js
@@ -41,8 +41,6 @@ export default class NetPyNESynapse extends React.Component {
         Utils.renameKey('netParams.synMechParams', storedValue, newValue, (response, newValue) => { that.renaming=false;});
         that.renaming=true;
       });
-    } else {
-      console.log("Rename forbidden, "+newValue+" already used.");
     }
   }
 

--- a/components/definition/synapses/NetPyNESynapses.js
+++ b/components/definition/synapses/NetPyNESynapses.js
@@ -34,7 +34,9 @@ export default class NetPyNESynapses extends React.Component {
     var value = defaultSynapses[key];
     var model = this.state.value;
     var SynapseId = Utils.getAvailableKey(model, key);
+    var newSynapse = Object.assign({name: SynapseId}, value);
     Utils.execPythonCommand('netpyne_geppetto.netParams.synMechParams["' + SynapseId + '"] = ' + JSON.stringify(value));
+    model[SynapseId] = newSynapse;
     this.setState({
       value: model,
       selectedSynapse: SynapseId

--- a/components/definition/synapses/NetPyNESynapses.js
+++ b/components/definition/synapses/NetPyNESynapses.js
@@ -13,11 +13,14 @@ export default class NetPyNESynapses extends React.Component {
     super(props);
     this.state = {
       selectedSynapse: undefined,
+      deletedSynapse: undefined,
       page: "main"
     };
     this.selectSynapse = this.selectSynapse.bind(this);
     this.handleNewSynapse = this.handleNewSynapse.bind(this);
     this.deleteSynapse = this.deleteSynapse.bind(this);
+
+    this.handleRenameChildren = this.handleRenameChildren.bind(this);
   };
 
   /* Method that handles button click */
@@ -64,7 +67,7 @@ export default class NetPyNESynapses extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     var newSynapseName = this.hasSelectedSynapseBeenRenamed(prevState, this.state);
     if (newSynapseName !== undefined) {
-      this.setState({ selectedSynapse: newSynapseName });
+      this.setState({ selectedSynapse: newSynapseName, deletedSynapse: undefined });
     };
   };
 
@@ -75,7 +78,7 @@ export default class NetPyNESynapses extends React.Component {
     var pageChanged = this.state.page != nextState.page;
     var newModel = this.state.value == undefined;
     if (this.state.value != undefined) {
-      newItemCreated = Object.keys(this.state.value).length != Object.keys(nextState.value).length;
+      newItemCreated = ((Object.keys(this.state.value).length != Object.keys(nextState.value).length) && (this.state.deletedSynapse !== undefined));
     };
     return newModel || newItemCreated || itemRenamed || selectionChanged || pageChanged;
   };
@@ -84,8 +87,19 @@ export default class NetPyNESynapses extends React.Component {
     Utils.sendPythonMessage('netpyne_geppetto.deleteParam', ["synMechParams['" + name + "']"]).then((response) =>{
       var model = this.state.value;
       delete model[name];
-      this.setState({value: model, selectedSynapse: undefined});
+      this.setState({value: model, selectedSynapse: undefined, deletedSynapse: name});
     });
+  }
+
+  handleRenameChildren(childName) {
+    childName = childName.replace(/\s*$/,"");
+    var childrenList = Object.keys(this.state.value);
+    for(var i=0 ; childrenList.length > i ; i++) {
+      if(childName === childrenList[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   render() {
@@ -102,7 +116,7 @@ export default class NetPyNESynapses extends React.Component {
     };
     var selectedSynapse = undefined;
     if ((this.state.selectedSynapse !== undefined) && Object.keys(model).indexOf(this.state.selectedSynapse) > -1) {
-      selectedSynapse = <NetPyNESynapse name={this.state.selectedSynapse} />;
+      selectedSynapse = <NetPyNESynapse name={this.state.selectedSynapse} renameHandler={this.handleRenameChildren} />;
     };
 
     return (


### PR DESCRIPTION
- Name collision issue fixed for all objects in the UI.

- During testing I noticed an issue was sitting there (experienced few times in the past) but due to the new logic implemented for the name collision was very easy to see this in all the elements of the UI with the exception of the population. Last commit is about this one, @adrianq @tarelli if you prefer 2 differents PRs let me know.
The issue is that on handleNew* functions the model was not changing with the new item and this was not triggering a refresh of the UI with the new element. The elements were created fine relying on the ui->backend messaging and synchronization between them but the ui was, just and only visually, out of synch.